### PR TITLE
Add wrapper wdl for smartseq2 single sample

### DIFF
--- a/docker/secondary-analysis-python/Dockerfile
+++ b/docker/secondary-analysis-python/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+
+MAINTAINER Dave Shiga <dshiga@broadinstitute.org> 
+LABEL software="Python"
+LABEL description="Python with some useful libraries"
+
+RUN pip install requests

--- a/docker/secondary-analysis-python/README.md
+++ b/docker/secondary-analysis-python/README.md
@@ -1,0 +1,1 @@
+Python image containing requests, for use in secondary analysis infrastructure tasks.

--- a/smartseq2_single_sample/hca-dcp/README.md
+++ b/smartseq2_single_sample/hca-dcp/README.md
@@ -1,0 +1,18 @@
+# Overview
+
+This directory contains a wrapper WDL used by the HCA Data Coordination Platform's Secondary Analysis Service to run the ss2_single_sample WDL. It is provided here mainly for informational purposes. Most people who want to run the SmartSeq2 pipeline should just run the ss2_single_sample.wdl directly.
+
+# Files
+
+* wrapper_ss2_single_sample.wdl
+The wrapper wdl, which calls prepare_and_analyze_ss2_single_sample.wdl and then submit_ss2_single_sample.wdl
+
+* prepare_and_analyze_ss2_single_sample.wdl
+Given a bundle uuid and version as inputs, queries the DCP Storage Service and obtain the actual fastq gs URLs needed to run ss2_single_sample.wdl, which it then runs.
+
+* submit_ss2_single_sample.wdl
+Submits the results from ss2_single_sample.wdl back to the DCP Ingest Service.
+
+# Do I need this?
+
+Only the Secondary Analysis Service should be trying to submit SmartSeq2 outputs to DCP Ingest. As mentioned above, if you want to run the SmartSeq2 pipeline you should probably run the ss2_single_sample.wdl directly. The prepare_and_analyze_ss2_single_sample.wdl might be useful to you if you want to translate bundle uuids and versions to fastq gs URLs.

--- a/smartseq2_single_sample/hca-dcp/prepare_and_analyze_ss2_single_sample.wdl
+++ b/smartseq2_single_sample/hca-dcp/prepare_and_analyze_ss2_single_sample.wdl
@@ -1,0 +1,119 @@
+import "ss2_single_sample.wdl" as ss2
+
+task GetInputs {
+  String bundle_uuid
+  String bundle_version
+
+  command <<<
+    python <<CODE
+    import json
+    import requests
+    import subprocess
+
+    # Get bundle manifest
+    uuid = '${bundle_uuid}'
+    version = '${bundle_version}'
+    print('Getting bundle manifest for id {0}, version {1}'.format(uuid, version))
+
+    url = "https://hca-dss.czi.technology/v1/bundles/" + uuid + "?version=" + version + "&replica=gcp&directurls=true"
+    print('GET {0}'.format(url))
+    response = requests.get(url)
+    print('{0}'.format(response.status_code))
+    print('{0}'.format(response.text))
+    manifest = response.json()
+
+    bundle = manifest['bundle']
+    uuid_to_url = {}
+    name_to_meta = {}
+    for f in bundle['files']:
+        uuid_to_url[f['uuid']] = f['url']
+        name_to_meta[f['name']] = f
+    
+    print('Downloading assay.json')
+    assay_json_uuid = name_to_meta['assay.json']['uuid']
+    url = "https://hca-dss.czi.technology/v1/files/" + assay_json_uuid + "?replica=gcp" 
+    print('GET {0}'.format(url))
+    response = requests.get(url)
+    print('{0}'.format(response.status_code))
+    print('{0}'.format(response.text))
+    assay_json = response.json()
+    
+    print('Downloading sample.json')
+    sample_json_uuid = name_to_meta['sample.json']['uuid']
+    url = "https://hca-dss.czi.technology/v1/files/" + sample_json_uuid + "?replica=gcp" 
+    print('GET {0}'.format(url))
+    response = requests.get(url)
+    print('{0}'.format(response.status_code))
+    print('{0}'.format(response.text))
+    sample_json = response.json()
+    sample_id = sample_json['geo_sample']
+
+    fastq_1_name = None
+    fastq_2_name = None
+    for f in assay_json['files']:
+        if f['format'] == '.fastq.gz' and f['type'] == 'read1':
+            fastq_1_name = f['name']
+        if f['format'] == '.fastq.gz' and f['type'] == 'read2':
+            fastq_2_name = f['name']
+
+    fastq_1_url = name_to_meta[fastq_1_name]['url']
+    fastq_2_url = name_to_meta[fastq_2_name]['url']
+
+    print('Creating input map')
+    with open('inputs.tsv', 'w') as f:
+        f.write('fastq_1\tfastq_2\tsample_id\n')
+        f.write('{0}\t{1}\t{2}\n'.format(fastq_1_url, fastq_2_url, sample_id))
+    print('Wrote input map')
+    CODE
+  >>>
+  runtime {
+    docker: "humancellatlas/secondary-analysis-python"
+  }
+  output {
+    Object inputs = read_object("inputs.tsv")
+  }
+}
+
+workflow PrepareAndAnalyzeSs2RsemSingleSample {
+  String bundle_uuid
+  String bundle_version
+
+  File gtf
+  File ref_fasta
+  File rrna_interval
+  File ref_flat
+  String star_genome
+  String rsem_genome
+
+  call GetInputs as prep {
+    input:
+      bundle_uuid = bundle_uuid,
+      bundle_version = bundle_version
+  }
+
+  call ss2.Ss2RsemSingleSample as analysis {
+    input:
+      fastq_read1 = prep.inputs.fastq_1,
+      fastq_read2 = prep.inputs.fastq_2,
+      output_prefix = prep.inputs.sample_id,
+      gtf = gtf,
+      ref_fasta = ref_fasta,
+      rrna_interval = rrna_interval,
+      ref_flat = ref_flat,
+      star_genome = star_genome,
+      rsem_genome = rsem_genome
+  }
+
+  output {
+    File bam_file = analysis.bam_file
+    File bam_trans = analysis.bam_trans
+    File rna_metrics = analysis.rna_metrics
+    File aln_metrics = analysis.aln_metrics
+    File rsem_gene_results = analysis.rsem_gene_results
+    File rsem_isoform_results = analysis.rsem_isoform_results
+    File rsem_gene_count = analysis.rsem_gene_count
+    File gene_unique_counts = analysis.gene_unique_counts
+    File exon_unique_counts = analysis.exon_unique_counts
+    File transcript_unique_counts = analysis.transcript_unique_counts
+  }
+}

--- a/smartseq2_single_sample/hca-dcp/submit_ss2_single_sample.wdl
+++ b/smartseq2_single_sample/hca-dcp/submit_ss2_single_sample.wdl
@@ -1,0 +1,37 @@
+task submit {
+  String i
+
+  command {
+    cat ${i} > out.txt
+    echo s >> out.txt
+  }
+  runtime {
+    docker: "ubuntu:17.04"
+  }
+  output {
+    File out = "out.txt"
+  }
+}
+
+workflow SubmitSs2RsemSingleSample {
+  File bam_file
+  File bam_trans
+  File rna_metrics
+  File aln_metrics
+  File rsem_gene_results
+  File rsem_isoform_results
+  File rsem_gene_count
+  File gene_unique_counts
+  File exon_unique_counts
+  File transcript_unique_counts
+  String i = "asdf"
+
+  call submit {
+    input:
+      i = i
+  }
+
+  output {
+    File o = submit.out
+  }
+}

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
@@ -1,0 +1,40 @@
+import "prepare_and_analyze_ss2_single_sample.wdl" as prep_and_analyze
+import "submit_ss2_single_sample.wdl" as submit
+
+workflow WrapperSs2RsemSingleSample {
+  String bundle_uuid
+  String bundle_version
+
+  File gtf
+  File ref_fasta
+  File rrna_interval
+  File ref_flat
+  String star_genome
+  String rsem_genome
+
+  call prep_and_analyze.PrepareAndAnalyzeSs2RsemSingleSample as prep_analyze {
+    input:
+      bundle_uuid = bundle_uuid,
+      bundle_version = bundle_version,
+      gtf = gtf,
+      ref_fasta = ref_fasta,
+      rrna_interval = rrna_interval,
+      ref_flat = ref_flat,
+      star_genome = star_genome,
+      rsem_genome = rsem_genome
+  }
+
+  call submit.SubmitSs2RsemSingleSample {
+    input:
+      bam_file = prep_analyze.bam_file,
+      bam_trans = prep_analyze.bam_trans,
+      rna_metrics = prep_analyze.rna_metrics,
+      aln_metrics = prep_analyze.aln_metrics,
+      rsem_gene_results = prep_analyze.rsem_gene_results,
+      rsem_isoform_results = prep_analyze.rsem_isoform_results,
+      rsem_gene_count = prep_analyze.rsem_gene_count,
+      gene_unique_counts = prep_analyze.gene_unique_counts,
+      exon_unique_counts = prep_analyze.exon_unique_counts,
+      transcript_unique_counts = prep_analyze.transcript_unique_counts
+  }
+}

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_bundle_specific.json
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_bundle_specific.json
@@ -1,0 +1,4 @@
+{
+  "WrapperSs2RsemSingleSample.bundle_uuid": "46cf0282-ac03-4c57-9274-c8e1bdd2aed7",  
+  "WrapperSs2RsemSingleSample.bundle_version": "2017-08-08T174816.194077Z"
+}

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_defaults.json
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_defaults.json
@@ -1,0 +1,8 @@
+{
+  "WrapperSs2RsemSingleSample.gtf": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/Gencode_v19/Gencode_v19.GTF",
+  "WrapperSs2RsemSingleSample.ref_fasta": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/Hg19.fa",
+  "WrapperSs2RsemSingleSample.ref_flat": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/refFlat.txt",
+  "WrapperSs2RsemSingleSample.rrna_interval": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/hg19.rRNA.interval_list",
+  "WrapperSs2RsemSingleSample.star_genome": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/star_hg19_gencode_v19.tar.gz",
+  "WrapperSs2RsemSingleSample.rsem_genome": "gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/rsem_hg19_gencode_v19.tar.gz"
+}


### PR DESCRIPTION
Adds a wrapper wdl for the smartseq2 single sample wdl. The smartseq2 wdl itself expects fastqs as inputs. The wrapper takes a bundle uuid and version and calls a prepare and analyze wdl, which translates the bundle uuid and version into fastq paths and then runs the smartseq2 wdl. Then the the wrapper wdl calls a submission task, which is just a placeholder for now, to be expanded in a future PR. The secondary analysis service will run the wrapper wdl, which it needs because it is triggered by notifications that contain just a bundle uuid and version.

See https://elastc.com/c/Kl2fPT8w/177-smartseq2-wrapper-wdl and https://elastc.com/c/ver8mz-b/123-preprocessing-wdl-for-smartseq2-pipeline. 