### PR TITLE
separated pip3 from uuid download, explained use

### DIFF
--- a/10x/analysis/example_data_processing.ipynb
+++ b/10x/analysis/example_data_processing.ipynb
@@ -9,8 +9,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -20,24 +22,42 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "total 0\n",
-      "drwxr-xr-x  3 ajc  staff  102 Oct  2 13:54 matrices_mex\n"
-     ]
-    }
-   ],
    "source": [
+    "The cell below will install and upgrade several python packages in your environment. if you have trouble running the import cell (5) below, uncomment and run this cell. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# uncomment to install\n",
+    "# pip3 install --upgrade hca  # grab the up-to-date hca command line tool and download the 10x data\n",
+    "# pip3 install --upgrade pandas \n",
+    "# pip3 install --upgrade numpy \n",
+    "# pip3 install --upgrade sklearn \n",
+    "# pip3 install --upgrade scipy \n",
+    "# pip3 install --upgrade matplotlib \n",
+    "# pip3 install --upgrade seaborn  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# download the uuid for the demo; note that this uuid appears to no longer be available.\n",
     "%%bash\n",
     "uuid=22d4e722-8d84-4255-81c9-822e8d09811d\n",
-    "# pip3 install --upgrade hca  # grab the up-to-date hca command line tool and download the 10x data\n",
-    "# pip3 install --upgrade pandas numpy sklearn scipy matplotlib seaborn  # for numerical analysis, plotting\n",
+    "\n",
     "hca dss download --replica aws ${uuid}   # download the data\n",
     "tar -xzf ./${uuid}/matrices_mex.tar.gz -C demo_work\n",
     "ls -l demo_work # list the directory with our files"


### PR DESCRIPTION
Added some clarity to the meaning of the pip3 install cell, separated from uuid downloading, and made clear that the demo uuid is no longer available.