### PR TITLE
Draft: Add wdl deploy script

### DIFF
--- a/scripts/deploy_pipelines.sh
+++ b/scripts/deploy_pipelines.sh
@@ -1,38 +1,118 @@
 #!/usr/bin/env bash
 
+# Usage:
+# bash deploy_pipelines.sh env infra_dir 10x_dir ss2_dir
+#
+# Where:
+#   -env is the environment, used in bucket name, e.g. dev or staging
+#   -infra_dir is the name of the subdirectory where wrapper wdls will be deployed
+#   -10x_dir is the name of the subdirectory where the 10x wdls will be deployed 
+#   -ss2_dir is the name of the subdirectory where the smartseq2 wdls will be deployed
+#
+# Example:
+# bash deploy_pipelines.sh dev ds_fix_submit_123 1.0.1 ah37fh9
+#
+# would deploy things as follows:
+#
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/analysis.wdl
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/infrastructure/ds_fix_submit_123/submit.wdl
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/infrastructure/ds_fix_submit_123/wrapper.wdl
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/infrastructure/ds_fix_submit_123/dependencies.zip
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/infrastructure/ds_fix_submit_123/static_inputs.json
+#  gs://broad-dsde-mint-dev-pipelines/10x/1.0.1/infrastructure/ds_fix_submit_123/options.json
+#
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/analysis.wdl
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/infrastructure/ds_fix_submit_123/submit.wdl
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/infrastructure/ds_fix_submit_123/wrapper.wdl
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/infrastructure/ds_fix_submit_123/dependencies.zip
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/infrastructure/ds_fix_submit_123/static_inputs.json
+#  gs://broad-dsde-mint-dev-pipelines/ss2/ah37fh9/infrastructure/ds_fix_submit_123/options.json
+
 set -e
 
 env=$1
-infra_version=$2
-tenx_version=$3
-ss2_version=$4
+infra_dir=$2
+tenx_dir=$3
+ss2_dir=$4
 bucket=broad-dsde-mint-$env-pipelines
 
 echo $env
-echo $infra_version
-echo $tenx_version
-echo $ss2_version
+echo $infra_dir
+echo $tenx_dir
+echo $ss2_dir
 echo $bucket
 
-# Deploy 10x
-cd ../10x/hca-dcp
-mkdir -p deploy
-cd deploy
-cp ../../count/count.wdl .
-cp ../../../hca-dcp/submit.wdl .
-if [ -e dependencies.zip ]; then
-  rm dependencies.zip
-fi
-zip dependencies.zip count.wdl submit.wdl
-gsutil cp count.wdl gs://$bucket/10x/$tenx_version/
-gsutil cp submit.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/submit.wdl
-gsutil cp ../wrapper_10x_count.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/wrapper.wdl
-gsutil cp ../wrapper_10x_count.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/wrapper.wdl
-gsutil cp dependencies.zip gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/dependencies.zip
-gsutil cp ../wrapper_10x_count_example_static.json gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/static_inputs.json
-gsutil cp ../10x_options.json gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/options.json
-gsutil ls gs://broad-dsde-mint-$env-pipelines/10x/$tenx_version/
-gsutil ls gs://broad-dsde-mint-$env-pipelines/10x/$tenx_version/infrastructure/$infra_version
-cd ../../../
+# Go to root of skylab repo
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $script_dir
+cd ../
+skylab_root=$(pwd)
 
-# TODO: Deploy Smart-seq2
+function copy_to_bucket()
+{
+  bucket=$1
+  pipeline_name=$2
+  pipeline_version=$3
+  infra_dir=$4
+  stage_dir=$5
+  gsutil cp $stage_dir/analysis.wdl gs://$bucket/$pipeline_name/$pipeline_version/
+  gsutil cp $stage_dir/submit.wdl gs://$bucket/$pipeline_name/$pipeline_version/infrastructure/$infra_dir/
+  gsutil cp $stage_dir/wrapper.wdl gs://$bucket/$pipeline_name/$pipeline_version/infrastructure/$infra_dir/
+  gsutil cp $stage_dir/dependencies.zip gs://$bucket/$pipeline_name/$pipeline_version/infrastructure/$infra_dir/
+  gsutil cp $stage_dir/static_inputs.json gs://$bucket/$pipeline_name/$pipeline_version/infrastructure/$infra_dir/
+  gsutil cp $stage_dir/options.json gs://$bucket/$pipeline_name/$pipeline_version/infrastructure/$infra_dir/options.json
+  gsutil ls gs://broad-dsde-mint-$env-pipelines/$pipeline_name/$pipeline_version/
+  gsutil ls gs://broad-dsde-mint-$env-pipelines/$pipeline_name/$pipeline_version/infrastructure/$infra_dir
+}
+
+function make_zip_file()
+{
+  stage_dir=$1
+  cd $stage_dir
+  if [ -e dependencies.zip ]; then
+    rm dependencies.zip
+  fi
+  zip dependencies.zip analysis.wdl submit.wdl
+  cd -
+}
+
+
+### Deploy 10x ###
+
+# Copy files to stage dir
+stage_dir=$skylab_root/10x/hca-dcp/stage
+local_infra_dir=$skylab_root/10x/hca-dcp
+analysis_dir=$skylab_root/10x/count
+mkdir -p $stage_dir
+cp $analysis_dir/count.wdl $stage_dir/analysis.wdl
+cp $skylab_root/hca-dcp/submit.wdl $stage_dir
+cp $local_infra_dir/wrapper_10x_count.wdl $stage_dir/wrapper.wdl
+cp $local_infra_dir/wrapper_10x_count_example_static.json $stage_dir/static_inputs.json
+cp $local_infra_dir/10x_options.json $stage_dir/options.json
+
+# Make zip file
+make_zip_file $stage_dir
+
+# Copy files to bucket
+copy_to_bucket $bucket 10x $tenx_dir $infra_dir $stage_dir
+
+
+### Deploy Smart-seq2 ###
+
+# Copy files to stage dir
+stage_dir=$skylab_root/smartseq2_single_sample/hca-dcp/stage
+local_infra_dir=$skylab_root/smartseq2_single_sample/hca-dcp
+analysis_dir=$skylab_root/smartseq2_single_sample
+mkdir -p $stage_dir
+cp $analysis_dir/ss2_single_sample.wdl $stage_dir/analysis.wdl
+cp $skylab_root/hca-dcp/submit.wdl $stage_dir
+cp $local_infra_dir/wrapper_ss2_single_sample.wdl $stage_dir/wrapper.wdl
+cp $local_infra_dir/wrapper_ss2_single_sample_example_static.json $stage_dir/static_inputs.json
+cp $local_infra_dir/ss2_options.json $stage_dir/options.json
+
+# Make zip file
+make_zip_file $stage_dir
+
+# Copy files to bucket
+copy_to_bucket $bucket ss2 $ss2_dir $infra_dir $stage_dir
+

--- a/scripts/deploy_pipelines.sh
+++ b/scripts/deploy_pipelines.sh
@@ -68,11 +68,12 @@ function copy_to_bucket()
 function make_zip_file()
 {
   stage_dir=$1
+  alt_wdl_name=$2
   cd $stage_dir
   if [ -e dependencies.zip ]; then
     rm dependencies.zip
   fi
-  zip dependencies.zip analysis.wdl submit.wdl
+  zip dependencies.zip analysis.wdl submit.wdl $alt_wdl_name
   cd -
 }
 
@@ -85,13 +86,14 @@ local_infra_dir=$skylab_root/10x/hca-dcp
 analysis_dir=$skylab_root/10x/count
 mkdir -p $stage_dir
 cp $analysis_dir/count.wdl $stage_dir/analysis.wdl
+cp $analysis_dir/count.wdl $stage_dir/
 cp $skylab_root/hca-dcp/submit.wdl $stage_dir
 cp $local_infra_dir/wrapper_10x_count.wdl $stage_dir/wrapper.wdl
 cp $local_infra_dir/wrapper_10x_count_example_static.json $stage_dir/static_inputs.json
 cp $local_infra_dir/10x_options.json $stage_dir/options.json
 
 # Make zip file
-make_zip_file $stage_dir
+make_zip_file $stage_dir count.wdl
 
 # Copy files to bucket
 copy_to_bucket $bucket 10x $tenx_dir $infra_dir $stage_dir
@@ -105,13 +107,14 @@ local_infra_dir=$skylab_root/smartseq2_single_sample/hca-dcp
 analysis_dir=$skylab_root/smartseq2_single_sample
 mkdir -p $stage_dir
 cp $analysis_dir/ss2_single_sample.wdl $stage_dir/analysis.wdl
+cp $analysis_dir/ss2_single_sample.wdl $stage_dir/
 cp $skylab_root/hca-dcp/submit.wdl $stage_dir
 cp $local_infra_dir/wrapper_ss2_single_sample.wdl $stage_dir/wrapper.wdl
 cp $local_infra_dir/wrapper_ss2_single_sample_example_static.json $stage_dir/static_inputs.json
 cp $local_infra_dir/ss2_options.json $stage_dir/options.json
 
 # Make zip file
-make_zip_file $stage_dir
+make_zip_file $stage_dir ss2_single_sample.wdl
 
 # Copy files to bucket
 copy_to_bucket $bucket ss2 $ss2_dir $infra_dir $stage_dir

--- a/scripts/deploy_pipelines.sh
+++ b/scripts/deploy_pipelines.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+env=$1
+infra_version=$2
+tenx_version=$3
+ss2_version=$4
+bucket=broad-dsde-mint-$env-pipelines
+
+echo $env
+echo $infra_version
+echo $tenx_version
+echo $ss2_version
+echo $bucket
+
+# Deploy 10x
+cd ../10x/hca-dcp
+mkdir -p deploy
+cd deploy
+cp ../../count/count.wdl .
+cp ../../../hca-dcp/submit.wdl .
+if [ -e dependencies.zip ]; then
+  rm dependencies.zip
+fi
+zip dependencies.zip count.wdl submit.wdl
+gsutil cp count.wdl gs://$bucket/10x/$tenx_version/
+gsutil cp submit.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/submit.wdl
+gsutil cp ../wrapper_10x_count.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/wrapper.wdl
+gsutil cp ../wrapper_10x_count.wdl gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/wrapper.wdl
+gsutil cp dependencies.zip gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/dependencies.zip
+gsutil cp ../wrapper_10x_count_example_static.json gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/static_inputs.json
+gsutil cp ../10x_options.json gs://$bucket/10x/$tenx_version/infrastructure/$infra_version/options.json
+gsutil ls gs://broad-dsde-mint-$env-pipelines/10x/$tenx_version/
+gsutil ls gs://broad-dsde-mint-$env-pipelines/10x/$tenx_version/infrastructure/$infra_version
+cd ../../../
+
+# TODO: Deploy Smart-seq2

--- a/scripts/run_deploy_pipelines.sh
+++ b/scripts/run_deploy_pipelines.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bash deploy_pipelines.sh dev fake_infra_branch fake_10x_version fake_ss2_version

--- a/scripts/run_deploy_pipelines.sh
+++ b/scripts/run_deploy_pipelines.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-bash deploy_pipelines.sh dev fake_infra_branch fake_10x_version fake_ss2_version
+bash deploy_pipelines.sh dev fake_infra_branch fake_10x_branch fake_ss2_branch


### PR DESCRIPTION
This adds a script that will copy wdls to a directory structure in a bucket that incorporates version numbers.

This will help us automate deployment, reduce manual copy errors, and avoid overwriting previous versions of wdl files.

Infrastructure / infra_version refers to the pipeline-tools repo where we will eventually put wrapper wdls.