### PR TITLE
Cw pass docker image as a parameter to submit wdl 296

### DIFF
--- a/10x/hca-dcp/wrapper_10x_count.wdl
+++ b/10x/hca-dcp/wrapper_10x_count.wdl
@@ -215,7 +215,7 @@ workflow Wrapper10xCount {
   Int timeout_seconds
 
   # Set Runtime Environment
-  String runtime_enviroånment
+  String runtime_environment
 
   call GetInputs {
     input:

--- a/10x/hca-dcp/wrapper_10x_count.wdl
+++ b/10x/hca-dcp/wrapper_10x_count.wdl
@@ -63,7 +63,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.2"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     Array[File] r1 = read_lines("r1.tsv")
@@ -97,7 +97,7 @@ task rename_files {
     CODE
   >>>
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.2"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     File r1_new = "${r1_name}"
@@ -183,7 +183,7 @@ task inputs_for_submit {
     CODE
   >>>
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.2"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     File inputs = "inputs.tsv"
@@ -214,7 +214,7 @@ workflow Wrapper10xCount {
   Int retry_seconds
   Int timeout_seconds
 
-  # Set Runtime Environment
+  # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
 
   call GetInputs {

--- a/10x/hca-dcp/wrapper_10x_count.wdl
+++ b/10x/hca-dcp/wrapper_10x_count.wdl
@@ -214,6 +214,9 @@ workflow Wrapper10xCount {
   Int retry_seconds
   Int timeout_seconds
 
+  # Set Runtime Environment
+  String runtime_enviroånment
+
   call GetInputs {
     input:
       bundle_uuid = bundle_uuid,
@@ -320,6 +323,7 @@ workflow Wrapper10xCount {
       schema_version = schema_version,
       method = method,
       retry_seconds = retry_seconds,
-      timeout_seconds = timeout_seconds
+      timeout_seconds = timeout_seconds,
+      runtime_environment = runtime_environment
   }
 }

--- a/10x/hca-dcp/wrapper_10x_count_example_static.json
+++ b/10x/hca-dcp/wrapper_10x_count_example_static.json
@@ -39,5 +39,6 @@
   "Wrapper10xCount.schema_version": "v3",
   "Wrapper10xCount.run_type": "run",
   "Wrapper10xCount.retry_seconds": 10,
-  "Wrapper10xCount.timeout_seconds": 600
+  "Wrapper10xCount.timeout_seconds": 600,
+  "Wrapper10xCount.runtime_environment": "dev"
 }

--- a/hca-dcp/submit.wdl
+++ b/hca-dcp/submit.wdl
@@ -24,7 +24,7 @@ task get_metadata {
       "https://cromwell.mint-${runtime_environment}.broadinstitute.org/api/workflows/v1/$(cat workflow_id.txt)/metadata" > metadata.json
   >>>
   runtime {
-    docker: "gcr.io/broad-dsde-${runtime_environment}/cromwell-metadata:0.1.1"
+    docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:0.1.1"
   }
   output {
     File metadata = "metadata.json"

--- a/hca-dcp/submit.wdl
+++ b/hca-dcp/submit.wdl
@@ -21,12 +21,10 @@ task get_metadata {
     creds=/cromwell-metadata/cromwell_credentials.txt
     curl -u $(cut -f1 $creds):$(cut -f2 $creds) \
       --compressed \
-      "$(cut -f3 $creds)/api/workflows/v1/$(cat workflow_id.txt)/metadata" > metadata.json
+      "https://cromwell.mint-${runtime_environment}.broadinstitute.org/api/workflows/v1/$(cat workflow_id.txt)/metadata" > metadata.json
   >>>
   runtime {
-    docker: if runtime_environment == "dev" then "gcr.io/broad-dsde-mint-dev/cromwell-metadata:0.1.0"
-            else if runtime_environment == "staging" then "gcr.io/broad-dsde-mint-staging/cromwell-metadata:0.1.0"
-            else "We cannot recognize the environment: " + runtime_environment
+    docker: "gcr.io/broad-dsde-${runtime_environment}/cromwell-metadata:0.1.1"
   }
   output {
     File metadata = "metadata.json"
@@ -71,7 +69,7 @@ task create_submission {
   >>>
 
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.3"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     File analysis_json = "analysis.json"
@@ -115,7 +113,7 @@ task stage_and_confirm {
   >>>
 
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.3"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
 }
 

--- a/hca-dcp/submit_example.json
+++ b/hca-dcp/submit_example.json
@@ -21,5 +21,6 @@
   "submit.schema_version": "v3",
   "submit.run_type": "run",
   "submit.retry_seconds": 10,
-  "submit.timeout_seconds": 120
+  "submit.timeout_seconds": 120,
+  "submit.runtime_environment": "dev"
 }

--- a/mock_smartseq2/hca-dcp/prepare_and_analyze_mock_smartseq2.wdl
+++ b/mock_smartseq2/hca-dcp/prepare_and_analyze_mock_smartseq2.wdl
@@ -67,7 +67,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.2"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     Object inputs = read_object("inputs.tsv")

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
@@ -40,7 +40,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "humancellatlas/secondary-analysis-python:0.1.2"
+    docker: "humancellatlas/secondary-analysis-python:0.1.4"
   }
   output {
     Object inputs = read_object("inputs.tsv")
@@ -69,7 +69,7 @@ workflow WrapperSs2RsemSingleSample {
   Int retry_seconds
   Int timeout_seconds
 
-  # Set Runtime Environment
+  # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
 
   call GetInputs as prep {

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample.wdl
@@ -69,6 +69,9 @@ workflow WrapperSs2RsemSingleSample {
   Int retry_seconds
   Int timeout_seconds
 
+  # Set Runtime Environment
+  String runtime_environment
+
   call GetInputs as prep {
     input:
       bundle_uuid = bundle_uuid,
@@ -151,6 +154,7 @@ workflow WrapperSs2RsemSingleSample {
       schema_version = schema_version,
       method = method,
       retry_seconds = retry_seconds,
-      timeout_seconds = timeout_seconds
+      timeout_seconds = timeout_seconds,
+      runtime_environment = runtime_environment
   }
 }

--- a/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_static.json
+++ b/smartseq2_single_sample/hca-dcp/wrapper_ss2_single_sample_example_static.json
@@ -13,5 +13,6 @@
   "WrapperSs2RsemSingleSample.schema_version": "v3",
   "WrapperSs2RsemSingleSample.run_type": "run",
   "WrapperSs2RsemSingleSample.retry_seconds": 10,
-  "WrapperSs2RsemSingleSample.timeout_seconds": 120
+  "WrapperSs2RsemSingleSample.timeout_seconds": 120,
+  "WrapperSs2RsemSingleSample.runtime_environment": "dev"
 }


### PR DESCRIPTION
The get_metadata task in the `submit.wdl` uses a different docker image for the staging vs. dev deployments. This PR passes in the docker image as a parameter to this task so the same version of the submit.wdl can be used when running workflows on both staging and dev.

Also modified wrapper wdls and sample inputs to adapt to the new parameter.