### PR TITLE
Cw update dev and staging to use latest code 286

### DIFF
--- a/docker/secondary-analysis-python/Dockerfile
+++ b/docker/secondary-analysis-python/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-LABEL maintainer="Dave Shiga <dshiga@broadinstitute.org>" \
+LABEL maintainer="Mint Team <mintteam@broadinstitute.org>" \
   software="Python" \
   description="Python2.7 with some useful libraries used for secondary-analysis-python application"
 

--- a/docker/secondary-analysis-python/Dockerfile
+++ b/docker/secondary-analysis-python/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:2.7
 
-MAINTAINER Dave Shiga <dshiga@broadinstitute.org> 
-LABEL software="Python"
-LABEL description="Python with some useful libraries"
+LABEL maintainer="Dave Shiga <dshiga@broadinstitute.org>" \
+  software="Python" \
+  description="Python2.7 with some useful libraries used for secondary-analysis-python application"
 
 RUN mkdir /tools
 
@@ -11,3 +11,6 @@ COPY tools /tools
 WORKDIR /tools
 
 RUN cd secondary_analysis && pip install .
+
+# Install hca-cli for submit.wdl
+RUN pip install hca==2.3.0

--- a/docker/secondary-analysis-python/Dockerfile
+++ b/docker/secondary-analysis-python/Dockerfile
@@ -12,5 +12,5 @@ WORKDIR /tools
 
 RUN cd secondary_analysis && pip install .
 
-# Install hca-cli for submit.wdl
-RUN pip install hca==2.3.0
+# Install the latest hca-cli for submit.wdl
+RUN pip install hca

--- a/hca-dcp/submit.wdl
+++ b/hca-dcp/submit.wdl
@@ -97,12 +97,16 @@ task stage_and_confirm {
         --retry_seconds ${retry_seconds} \
         --timeout_seconds ${timeout_seconds})
 
+    # Select staging area
+    echo "hca upload select $staging_urn"
+    hca upload select $staging_urn
+
     # Stage the files
     files=( ${sep=' ' files} )
     for f in "$${lb}files[@]${rb}"
     do
-      echo "stage $f $staging_urn"
-      stage $f $staging_urn
+      echo "hca upload file $f"
+      hca upload file $f
     done
 
     # Confirm the submission


### PR DESCRIPTION
This PR covers checklist below:
- [x] Fix staging upload files step in submit.wdl.
- [x] Update secondary-analysis-python docker image to use latest `hca-cli` tool.
- [x] Fix GCR permission issue, pass runtime_environment as a parameter, update cromwell-metadata docker image and push to both `dev` and `staging` GCR. (covered by Ticket#296)
- [x] Deploy updated 10x wdls to `dev` bucket.
- [x] Deploy updated ss2 wdls to `dev` bucket.
- [x] Deploy updated 10x wdls to `staging` bucket.
- [x] Deploy updated ss2 wdls to `staging` bucket.
- [x] Working with Blue and Purple Boxes to do integration sessions.
- [x] DCP-wide Integration Test 1.
- [ ] Update Deployment of `dev` listener.
- [ ] Update Deployment of `staging` listener.
- [ ] Tracking table of Docker images during development and deployment.
- [ ] DCP-wide Integration Test 2.
