### PR TITLE
Ajc pr test

### DIFF
--- a/optimus/Optimus.wdl
+++ b/optimus/Optimus.wdl
@@ -2,7 +2,7 @@ import "FastqToUBam.wdl" as fq2bam
 import "Attach10xBarcodes.wdl" as attach
 import "SplitBamByCellBarcode.wdl" as split
 import "CollectMultiplePicardMetrics.wdl" as collect
-import "MergeBam.wdl" as merge
+import "MergeSortBam.wdl" as merge
 import "CreateCountMatrix.wdl" as count
 import "AlignTagCorrectUmis.wdl" as AlignTagCorrectUmis
 
@@ -50,7 +50,7 @@ workflow Optimus {
     }
   }
 
-  call merge.MergeBam {
+  call merge.MergeSortBam {
     input:
       bam_inputs = AlignTagCorrectUmis.bam_outputs
   }

--- a/pipelines/tasks/MergeBam.wdl
+++ b/pipelines/tasks/MergeBam.wdl
@@ -4,7 +4,8 @@ task MergeBam {
 
   command {
     flat_inputs=$(python -c "print '${sep=' ' bam_inputs}'.replace('[', '').replace(']', '')")
-    samtools merge out.bam $flat_inputs
+    samtools merge -c -p out.bam $flat_inputs
+    samtools sort -o out_sorted.bam out.bam
   }
   
   runtime {
@@ -15,6 +16,6 @@ task MergeBam {
   }
   
   output {
-    File bam_output = "out.bam"
+    File bam_output = "out_sorted.bam"
   }
 }

--- a/pipelines/tasks/MergeSortBam.wdl
+++ b/pipelines/tasks/MergeSortBam.wdl
@@ -1,5 +1,5 @@
 
-task MergeBam {
+task MergeSortBam {
   Array[Array[File]] bam_inputs
 
   command {

--- a/pipelines/tasks/StarAlignBamSingleEnd.wdl
+++ b/pipelines/tasks/StarAlignBamSingleEnd.wdl
@@ -21,9 +21,13 @@ task StarAlignBamSingleEnd {
       --genomeDir genome_reference \
       --readFilesIn "${bam_input}" \
       --outSAMtype BAM Unsorted \
+      --outSAMattributes All \
+      --outFilterMultimapNmax 1 \
+      --outSAMunmapped Within \
+      --outSAMprimaryFlag AllBestScore \
       --readFilesType SAM SE \
-      --readFilesCommand samtools view -h
-
+      --readFilesCommand samtools view -h \
+      --runRNGseed 777
   }
 
   runtime {

--- a/test/config/cromwell-secrets.json.ctmpl
+++ b/test/config/cromwell-secrets.json.ctmpl
@@ -1,0 +1,8 @@
+{{with $environment := env "ENVIRONMENT"}}
+{{with $cromwellSecrets := vault (printf "secret/dsde/mint/%s/cromwell/cromwell-login" $environment)}}
+{
+  "cromwell_user": "{{$cromwellSecrets.Data.cromwell_user}}",
+  "cromwell_password": "{{$cromwellSecrets.Data.cromwell_password}}"
+}
+{{end}}
+{{end}}

--- a/test/config/render-ctmpls.sh
+++ b/test/config/render-ctmpls.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+env=$1
+vault_token=$2
+working_dir=${3:-$PWD}
+docker_image=broadinstitute/dsde-toolbox:latest
+
+echo $(ls ${working_dir}/test/config)
+
+printf "pulling docker image ${docker_image}"
+docker pull "${docker_image}"
+
+printf "Creating Cromwell config\n"
+docker run --rm -v ${working_dir}:/working \
+    -e VAULT_TOKEN=${vault_token} \
+    -e INPUT_PATH=/working/test/config \
+    -e OUT_PATH=/working/test \
+    "${docker_image}" render-templates.sh ${env}

--- a/test/config/render-ctmpls.sh
+++ b/test/config/render-ctmpls.sh
@@ -7,10 +7,10 @@ docker_image=broadinstitute/dsde-toolbox:latest
 
 echo $(ls ${working_dir}/test/config)
 
-printf "pulling docker image ${docker_image}"
+echo "pulling docker image ${docker_image}"
 docker pull "${docker_image}"
 
-printf "Creating Cromwell config\n"
+echo "Creating Cromwell config"
 docker run --rm -v ${working_dir}:/working \
     -e VAULT_TOKEN=${vault_token} \
     -e INPUT_PATH=/working/test/config \

--- a/test/optimus/pr/TestOptimusPR.wdl
+++ b/test/optimus/pr/TestOptimusPR.wdl
@@ -1,0 +1,45 @@
+import "Optimus.wdl" as target
+import "ValidateOptimus.wdl" as checker
+
+
+# this task will be run by the jenkins script that gets executed on our PRs.
+
+workflow TestOptimusPR {
+
+  # output hashes
+  String expected_bam_hash
+  String expected_matrix_hash
+  String expected_matrix_summary_hash
+  String expected_picard_metrics_hash
+
+  # Optimus inputs
+  Array[Array[File]] fastq_inputs  # array of arrays of matched fastqs [ [r1, r2, i1], ... ]
+  File whitelist  # 10x genomics cell barcode whitelist for 10x V2
+  File tar_star_reference  # star reference
+  File annotations_gtf  # gtf containing annotations for gene tagging
+  File ref_genome_fasta  # genome fasta file
+  String sample_id  # name of sample matching this file, inserted into read group header
+
+  call target.Optimus as target {
+    input:
+      fastq_inputs = fastq_inputs,
+      whitelist = whitelist,
+      tar_star_reference = tar_star_reference,
+      annotations_gtf = annotations_gtf,
+      ref_genome_fasta = ref_genome_fasta,
+      sample_id = sample_id
+  }
+
+  call checker.ValidateOptimus as checker {
+    input:
+      bam = target.bam,
+      matrix = target.matrix,
+      matrix_summary = target.matrix_summary,
+      picard_metrics = target.picard_metrics,
+      expected_bam_hash = expected_bam_hash,
+      expected_matrix_hash = expected_matrix_hash,
+      expected_matrix_summary_hash = expected_matrix_summary_hash,
+      expected_picard_metrics_hash = expected_picard_metrics_hash
+  }
+
+}

--- a/test/optimus/pr/ValidateOptimus.wdl
+++ b/test/optimus/pr/ValidateOptimus.wdl
@@ -10,18 +10,19 @@ task ValidateOptimus {
       String expected_matrix_hash
       String expected_matrix_summary_hash
       String expected_picard_metrics_hash
-      # # these are also inputs; lets leave them alone until flattening is in WDL
-      # Array[Array[File]] tag_gene_exon_log
-      # Array[Array[File]] umi_metrics
-      # Array[Array[File]] duplicate_metrics
 
   command <<<
 
+    # catch intermittent failures
+    set -eo pipefail
+
     # calculate hashes; awk is used to extract the hash from the md5sum output that contains both
     # a hash and the filename that was passed
-    bam_hash=$(samtools view "${bam}" | md5sum | awk '{print $1}')
     matrix_hash=$(md5sum "${matrix}" | awk '{print $1}')
     matrix_summary_hash=$(md5sum "${matrix_summary}" | awk '{print $1}')
+
+    # calculate hash as above, but ignore run-specific bam headers
+    bam_hash=$(samtools view "${bam}" | md5sum | awk '{print $1}')
 
     # the picard metrics are contained in a .tar.gz file; in addition to the above processing,
     # this unzips the archive, and parses it with awk to remove all the run-specific comment lines (#)

--- a/test/optimus/pr/ValidateOptimus.wdl
+++ b/test/optimus/pr/ValidateOptimus.wdl
@@ -1,0 +1,62 @@
+
+task ValidateOptimus {
+      File bam
+      File matrix
+      File matrix_summary
+      File picard_metrics
+      Int required_disk = ceil((size(bam, "G") + size(matrix, "G") + size(matrix_summary, "G") + size(picard_metrics, "G")) * 1.1)
+
+      String expected_bam_hash
+      String expected_matrix_hash
+      String expected_matrix_summary_hash
+      String expected_picard_metrics_hash
+      # # these are also inputs; lets leave them alone until flattening is in WDL
+      # Array[Array[File]] tag_gene_exon_log
+      # Array[Array[File]] umi_metrics
+      # Array[Array[File]] duplicate_metrics
+
+  command <<<
+
+    # calculate hashes; awk is used to extract the hash from the md5sum output that contains both
+    # a hash and the filename that was passed
+    bam_hash=$(samtools view "${bam}" | md5sum | awk '{print $1}')
+    matrix_hash=$(md5sum "${matrix}" | awk '{print $1}')
+    matrix_summary_hash=$(md5sum "${matrix_summary}" | awk '{print $1}')
+
+    # the picard metrics are contained in a .tar.gz file; in addition to the above processing,
+    # this unzips the archive, and parses it with awk to remove all the run-specific comment lines (#)
+    picard_metrics_hash=$(gunzip -c "${picard_metrics}" | awk 'NF && $1!~/^#/' | md5sum | awk '{print $1}')
+
+    # test each output for equivalence, echoing any failure states to stdout
+    fail=false
+    if [ "$bam_hash" != "${expected_bam_hash}" ]; then
+      >&2 echo "bam_hash ($bam_hash) did not match expected hash (${expected_bam_hash})"
+      fail=true
+    fi
+    
+    if [ "$matrix_hash" != "${expected_matrix_hash}" ]; then
+      >&2 echo "matrix_hash ($matrix_hash) did not match expected hash (${expected_matrix_hash})"
+      fail=true
+    fi
+
+    if [ "$matrix_summary_hash" != "${expected_matrix_summary_hash}" ]; then
+      >&2 echo "matrix_summary_hash ($matrix_summary_hash) did not match expected hash (${expected_matrix_summary_hash})"
+      fail=true
+    fi
+
+    if [ "$picard_metrics_hash" != "${expected_picard_metrics_hash}" ]; then
+      >&2 echo "picard_metrics_hash ($picard_metrics_hash) did not match expected hash (${expected_picard_metrics_hash})"
+      fail=true
+    fi
+    
+    if [ $fail == "true" ]; then exit 1; fi
+
+  >>>
+  
+  runtime {
+    docker: "humancellatlas/samtools:1.3.1"
+    cpu: 1
+    memory: "3.75 GB"
+    disks: "local-disk ${required_disk} HDD"
+  }
+}

--- a/test/optimus/pr/dependencies.json
+++ b/test/optimus/pr/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "Optimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/Optimus.wdl",
+  "ValidateOptimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/optimus/pr/ValidateOptimus.wdl",
+  "AlignTagCorrectUmis.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/AlignTagCorrectUmis.wdl",
+  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/StarAlignBamSingleEnd.wdl",
+  "FastqToUBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/FastqToUBam.wdl",
+  "Attach10xBarcodes.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/Attach10xBarcodes.wdl",
+  "SplitBamByCellBarcode.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/SplitBamByCellBarcode.wdl",
+  "TagGeneExon.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/TagGeneExon.wdl",
+  "CorrectUmiMarkDuplicates.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CorrectUmiMarkDuplicates.wdl",
+  "CollectMultiplePicardMetrics.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CollectMultiplePicardMetrics.wdl",
+  "MergeBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/MergeBam.wdl",
+  "CreateCountMatrix.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CreateCountMatrix.wdl"
+}

--- a/test/optimus/pr/dependencies.json
+++ b/test/optimus/pr/dependencies.json
@@ -1,14 +1,14 @@
 {
   "Optimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/Optimus.wdl",
-  "ValidateOptimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/optimus/pr/ValidateOptimus.wdl",
+  "ValidateOptimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/test/optimus/pr/ValidateOptimus.wdl",
   "AlignTagCorrectUmis.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/AlignTagCorrectUmis.wdl",
-  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/StarAlignBamSingleEnd.wdl",
+  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/StarAlignBamSingleEnd.wdl",
   "FastqToUBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/FastqToUBam.wdl",
   "Attach10xBarcodes.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/Attach10xBarcodes.wdl",
   "SplitBamByCellBarcode.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/SplitBamByCellBarcode.wdl",
   "TagGeneExon.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/TagGeneExon.wdl",
   "CorrectUmiMarkDuplicates.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CorrectUmiMarkDuplicates.wdl",
   "CollectMultiplePicardMetrics.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CollectMultiplePicardMetrics.wdl",
-  "MergeBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/MergeBam.wdl",
+  "MergeSortBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/MergeSortBam.wdl",
   "CreateCountMatrix.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CreateCountMatrix.wdl"
 }

--- a/test/optimus/pr/test_inputs.json
+++ b/test/optimus/pr/test_inputs.json
@@ -1,0 +1,23 @@
+{
+  "TestOptimusPR.expected_bam_hash": "8c03262b5bd383abd237e5c1dab202bd",
+  "TestOptimusPR.expected_matrix_hash": "69f3be6085e0c5f694b3cfa877b0eeaa",
+  "TestOptimusPR.expected_matrix_summary_hash": "dd513351d4e7688c97f7bf902ba2876f",
+  "TestOptimusPR.expected_picard_metrics_hash": "7b7be5c9a2236920ca09f05811dca6d5",
+  "TestOptimusPR.fastq_inputs": [
+    [
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
+    ],
+    [
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
+    ]
+  ],
+  "TestOptimusPR.whitelist": "gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt",
+  "TestOptimusPR.tar_star_reference": "gs://broad-dsde-mint-dev-teststorage/demo/star.tar",
+  "TestOptimusPR.sample_id": "pbmc8k_test",
+  "TestOptimusPR.annotations_gtf": "gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz",
+  "TestOptimusPR.ref_genome_fasta": "gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa"
+}

--- a/test/optimus/scientific/ScientificTests.wdl
+++ b/test/optimus/scientific/ScientificTests.wdl
@@ -5,9 +5,13 @@
 task TestBamRecordNumber {
   File bam
   Int expected_records
-  Int required_disk = ceil(size(bam, "G") * 2)
+  Int required_disk = ceil(size(bam, "G") * 1.2)
 
   command {
+
+    # catch uncommon errors
+    -eo pipefail
+
     N_RECORDS=$(samtools view "${bam}" | wc -l)
     if [ $N_RECORDS != "${expected_records}" ]; then
         >&2 echo "Number of records in the pipeline output ($N_RECORDS) did not match the expected number (${expected_records})"

--- a/test/optimus/scientific/ScientificTests.wdl
+++ b/test/optimus/scientific/ScientificTests.wdl
@@ -1,0 +1,24 @@
+
+# note that this is not a great test because it localizes the .bam file
+# however it is a good placeholder while we put together the scientific tests
+# themselves, as these files will be relatively small in the testing data.
+task TestBamRecordNumber {
+  File bam
+  Int expected_records
+  Int required_disk = ceil(size(bam, "G") * 2)
+
+  command {
+    N_RECORDS=$(samtools view "${bam}" | wc -l)
+    if [ $N_RECORDS != "${expected_records}" ]; then
+        >&2 echo "Number of records in the pipeline output ($N_RECORDS) did not match the expected number (${expected_records})"
+        exit 1
+    fi
+  }
+  
+  runtime {
+    docker: "humancellatlas/samtools:1.3.1"
+    cpu: 1
+    memory: "3.75 GB"
+    disks: "local-disk ${required_disk} HDD"
+  }
+}

--- a/test/optimus/scientific/TestOptimusScientific.wdl
+++ b/test/optimus/scientific/TestOptimusScientific.wdl
@@ -1,0 +1,28 @@
+import "Optimus.wdl" as target
+import "ScientificTests.wdl" as tests
+
+workflow TestOptimusScientific {
+  Array[Array[File]] fastq_inputs
+  File whitelist
+  File tar_star_reference
+  File annotations_gtf
+  File ref_genome_fasta
+  String sample_id
+  Int expected_number_bam_records
+
+  call target.Optimus as target {
+    input:
+      fastq_inputs = fastq_inputs,
+      whitelist = whitelist,
+      tar_star_reference = tar_star_reference,
+      annotations_gtf = annotations_gtf,
+      ref_genome_fasta = ref_genome_fasta,
+  }
+      sample_id = sample_id
+
+  call tests.TestBamRecordNumber as test {
+    input:
+      bam = target.bam,
+      expected_records = expected_number_bam_records
+  }
+}

--- a/test/optimus/scientific/dependencies.json
+++ b/test/optimus/scientific/dependencies.json
@@ -1,0 +1,14 @@
+{
+  "Optimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/Optimus.wdl",
+  "ScientificTests.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/optimus/scientific/ScientificTests.wdl",
+  "AlignTagCorrectUmis.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/AlignTagCorrectUmis.wdl",
+  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/StarAlignBamSingleEnd.wdl",
+  "FastqToUBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/FastqToUBam.wdl",
+  "Attach10xBarcodes.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/Attach10xBarcodes.wdl",
+  "SplitBamByCellBarcode.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/SplitBamByCellBarcode.wdl",
+  "TagGeneExon.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/TagGeneExon.wdl",
+  "CorrectUmiMarkDuplicates.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CorrectUmiMarkDuplicates.wdl",
+  "CollectMultiplePicardMetrics.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CollectMultiplePicardMetrics.wdl",
+  "MergeBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/MergeBam.wdl",
+  "CreateCountMatrix.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CreateCountMatrix.wdl"
+}

--- a/test/optimus/scientific/dependencies.json
+++ b/test/optimus/scientific/dependencies.json
@@ -1,14 +1,14 @@
 {
   "Optimus.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/Optimus.wdl",
-  "ScientificTests.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/optimus/scientific/ScientificTests.wdl",
+  "ScientificTests.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/test/optimus/scientific/ScientificTests.wdl",
   "AlignTagCorrectUmis.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/optimus/AlignTagCorrectUmis.wdl",
-  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/StarAlignBamSingleEnd.wdl",
+  "StarAlignBamSingleEnd.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/StarAlignBamSingleEnd.wdl",
   "FastqToUBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/FastqToUBam.wdl",
   "Attach10xBarcodes.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/Attach10xBarcodes.wdl",
   "SplitBamByCellBarcode.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/SplitBamByCellBarcode.wdl",
   "TagGeneExon.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/TagGeneExon.wdl",
   "CorrectUmiMarkDuplicates.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CorrectUmiMarkDuplicates.wdl",
   "CollectMultiplePicardMetrics.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CollectMultiplePicardMetrics.wdl",
-  "MergeBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/pipelines/tasks/MergeBam.wdl",
+  "MergeSortBam.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/MergeSortBam.wdl",
   "CreateCountMatrix.wdl": "https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/pipelines/tasks/CreateCountMatrix.wdl"
 }

--- a/test/optimus/scientific/test_inputs.json
+++ b/test/optimus/scientific/test_inputs.json
@@ -1,0 +1,20 @@
+{
+ "TestOptimusScientific.fastq_inputs": [
+    [
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
+    ],
+    [
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
+      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
+    ]
+  ],
+  "TestOptimusScientific.whitelist": "gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt",
+  "TestOptimusScientific.tar_star_reference": "gs://broad-dsde-mint-dev-teststorage/demo/star.tar",
+  "TestOptimusScientific.sample_id": "pbmc_scientific_test",
+  "TestOptimusScientific.annotations_gtf": "gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz",
+  "TestOptimusScientific.ref_genome_fasta": "gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa",
+  "TestOptimusScientific.expected_number_bam_records": 24000
+}

--- a/test/options.json
+++ b/test/options.json
@@ -1,0 +1,3 @@
+{
+  "read_from_cache": false
+}

--- a/test/test_cromwell_workflow.sh
+++ b/test/test_cromwell_workflow.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CROMWELL_USER=$1
 CROMWELL_PASSWORD=$2
 CROMWELL_URL=$3

--- a/test/test_cromwell_workflow.sh
+++ b/test/test_cromwell_workflow.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+CROMWELL_USER=$1
+CROMWELL_PASSWORD=$2
+CROMWELL_URL=$3
+INPUTS_JSON=$4
+WDL_FILE=$5
+OPTIONS_FILE=$6
+DEPENDENCIES_JSON=$7
+
+echo "Starting workflow."
+WORKFLOW_HASH=$(cromwell-tools run \
+  --username "${CROMWELL_USER}" \
+  --password "${CROMWELL_PASSWORD}" \
+  --cromwell-url "${CROMWELL_URL}" \
+  --inputs-json "${INPUTS_JSON}" \
+  --wdl-file "${WDL_FILE}" \
+  --options-file "${OPTIONS_FILE}" \
+  --dependencies-json "${DEPENDENCIES_JSON}" \
+)
+
+echo "Waiting for workflow to complete..."
+cromwell-tools wait \
+  --username "${CROMWELL_USER}" \
+  --password "${CROMWELL_PASSWORD}" \
+  --cromwell-url "${CROMWELL_URL}" \
+  --workflow-ids "${WORKFLOW_HASH}" \
+  --timeout-minutes 60 \
+  --poll-interval-seconds 30
+
+echo "Checking workflow completion status."
+STATUS_RESULT=$(cromwell-tools status \
+  --username "${CROMWELL_USER}" \
+  --password "${CROMWELL_PASSWORD}" \
+  --cromwell-url "${CROMWELL_URL}" \
+  --workflow-ids "${WORKFLOW_HASH}" \
+)
+echo "${STATUS_RESULT}"
+
+# get the status alone; cromwell tools is a bit more verbose
+STATUS=$(echo "${STATUS_RESULT}" | awk '{print $NF}')
+
+if [ "${STATUS}" == "Succeeded" ]; then
+  echo "Test Successful. Workflow outputs matched expected values."
+  exit 0
+else
+  echo "Test Failed. Workflow ${WORKFLOW_HASH} did not match expected outputs. See logs for listed workflow for more details."
+  exit 1
+fi

--- a/test/test_optimus_checker.ipynb
+++ b/test/test_optimus_checker.ipynb
@@ -1,0 +1,898 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "from google.cloud import storage\n",
+    "import cromwell_manager as cwm\n",
+    "\n",
+    "with open(os.path.expanduser('~/.ssh/mint_cromwell_config.json')) as f:\n",
+    "    cromwell_server = cwm.Cromwell(**json.load(f))\n",
+    "\n",
+    "storage_client = storage.Client(project='broad-dsde-mint-dev')\n",
+    "\n",
+    "os.environ['wdltool'] = '/Users/ajc/google_drive/software/wdltool-0.14.jar'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "inputs_json = {\n",
+    "    'TestOptimus.expected_bam_hash': '06201722dc6c897261daf9d032377cc8',\n",
+    "    'TestOptimus.expected_matrix_hash': '69f3be6085e0c5f694b3cfa877b0eeaa',\n",
+    "    'TestOptimus.expected_matrix_summary_hash': 'dd513351d4e7688c97f7bf902ba2876f',\n",
+    "    'TestOptimus.expected_picard_metrics_hash': '1c3af42240367ae4dd4cc5f96e70b7ce',\n",
+    "    \"TestOptimus.fastq_inputs\": [\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\n",
+    "      ],\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1a_L007_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\n",
+    "      ]\n",
+    "    ],\n",
+    "    \"TestOptimus.whitelist\": \"gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt\",\n",
+    "    \"TestOptimus.tar_star_reference\": \"gs://broad-dsde-mint-dev-teststorage/demo/star.tar\",\n",
+    "    \"TestOptimus.sample_name\": \"pbmc8k_test\",\n",
+    "    \"TestOptimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",\n",
+    "    \"TestOptimus.ref_genome_fasta\": \"gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa\"\n",
+    "}\n",
+    "\n",
+    "wdl = \"TestOptimus.wdl\"\n",
+    "# options_json = \"../adapter_pipelines/Optimus/options.json\"  # no caching \n",
+    "workflow_dependencies = {\n",
+    "    'Optimus.wdl': '../optimus/Optimus.wdl',\n",
+    "    'ValidateOptimus.wdl': 'ValidateOptimus.wdl',\n",
+    "    \"StarAlignBamSingleEnd.wdl\": \"../pipelines/tasks/StarAlignBamSingleEnd.wdl\",\n",
+    "    \"FastqToUBam.wdl\": \"../pipelines/tasks/FastqToUBam.wdl\",\n",
+    "    \"Attach10xBarcodes.wdl\": \"../pipelines/tasks/Attach10xBarcodes.wdl\",\n",
+    "    \"SplitBamByCellBarcode.wdl\": \"../pipelines/tasks/SplitBamByCellBarcode.wdl\",\n",
+    "    \"TagGeneExon.wdl\": \"../pipelines/tasks/TagGeneExon.wdl\",\n",
+    "    \"CorrectUmiMarkDuplicates.wdl\": \"../pipelines/tasks/CorrectUmiMarkDuplicates.wdl\",\n",
+    "    \"CollectMultiplePicardMetrics.wdl\": \"../pipelines/tasks/CollectMultiplePicardMetrics.wdl\",\n",
+    "    \"MergeBam.wdl\": \"../pipelines/tasks/MergeBam.wdl\",\n",
+    "    \"CreateCountMatrix.wdl\": \"../pipelines/tasks/CreateCountMatrix.wdl\",\n",
+    "    \"AlignTagCorrectUmis.wdl\": \"../optimus/AlignTagCorrectUmis.wdl\"    \n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "options_json = {\n",
+    "    \"read_from_cache\": False,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open('test_inputs_temp.json', 'w') as f:\n",
+    "    json.dump(inputs_json, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cat test_inputs_temp.json | jq . > test_inputs.json\n",
+    "rm test_inputs_temp.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open('dependencies_temp.json', 'w') as f:\n",
+    "    json.dump(workflow_dependencies, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cat dependencies_temp.json | jq . > dependencies.json\n",
+    "rm dependencies_temp.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open('options_temp.json', 'w') as f:\n",
+    "    json.dump(options_json, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cat options_temp.json | jq . > options.json\n",
+    "rm options_temp.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CWM:2017-12-05 17:37:19.381609:creating temporary directory\n",
+      "CWM:2017-12-05 17:37:19.382959:writing dependencies\n",
+      "CWM:2017-12-05 17:37:19.397641:writing wdl\n",
+      "CWM:2017-12-05 17:37:19.398868:running wdltool validate\n",
+      "CWM:2017-12-05 17:37:20.920296:validation successful\n",
+      "CWM:2017-12-05 17:37:21.232200:checking docker image humancellatlas/dropseqtools:1.12... OK.\n",
+      "CWM:2017-12-05 17:37:21.414104:checking docker image ubuntu:17.04... not found. Is image private?\n",
+      "CWM:2017-12-05 17:37:22.470443:checking docker image humancellatlas/picard:2.10.10... OK.\n",
+      "CWM:2017-12-05 17:37:22.705134:checking docker image humancellatlas/samtools:1.3.1... OK.\n",
+      "CWM:2017-12-05 17:37:22.976520:checking docker image humancellatlas/star:2.5.3a-40ead6e... OK.\n",
+      "CWM:2017-12-05 17:37:23.203105:checking docker image humancellatlas/python3-scientific:0.1.3... OK.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "cwm.Workflow.validate(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=inputs_json,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=workflow_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wf = cwm.Workflow.from_submission(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=inputs_json,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=workflow_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'f8ba61dc-bf8a-4c1e-8c69-f22608a571d8', 'status': 'Succeeded'}"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wf.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bam_hash (06201722dc6c897261daf9d032377cc8  /cromwell_root/broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-target/Optimus/866e61bf-188b-4ec3-a8a4-abd12b83ea09/call-MergeBam/out.bam) did not match expected hash (a85318fbf34a5e3ce13ddfbd73732771)\n",
+      "matrix_hash (69f3be6085e0c5f694b3cfa877b0eeaa  /cromwell_root/broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-target/Optimus/866e61bf-188b-4ec3-a8a4-abd12b83ea09/call-DropSeqToolsDigitalExpression/digital_expression.txt.gz) did not match expected hash (69f3be6085e0c5f694b3cfa877b0eeaa)\n",
+      "matrix_summary_hash (dd513351d4e7688c97f7bf902ba2876f  /cromwell_root/broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-target/Optimus/866e61bf-188b-4ec3-a8a4-abd12b83ea09/call-DropSeqToolsDigitalExpression/digital_expression_summary.txt) did not match expected hash (dd513351d4e7688c97f7bf902ba2876f)\n",
+      "matrix_summary_hash (dd513351d4e7688c97f7bf902ba2876f  /cromwell_root/broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-target/Optimus/866e61bf-188b-4ec3-a8a4-abd12b83ea09/call-DropSeqToolsDigitalExpression/digital_expression_summary.txt) did not match expected hash (dd513351d4e7688c97f7bf902ba2876f)\n",
+      "picard_metrics_hash (1c3af42240367ae4dd4cc5f96e70b7ce  /cromwell_root/broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-target/Optimus/866e61bf-188b-4ec3-a8a4-abd12b83ea09/call-CollectMultipleMetrics/pbmc8k_test.tar.gz) did not match expected hash (36101cca60876ab8733729961366322d)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil cat gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/9c92e1f3-ec44-4e25-8ee8-e2d4d7dd82de/call-checker/checker-stderr.log"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "failing_inputs_json = {\n",
+    "    'TestOptimus.expected_bam_hash': 'IShouldDefinitelyNotPassBecauseImTheWrongHash',\n",
+    "    'TestOptimus.expected_matrix_hash': '69f3be6085e0c5f694b3cfa877b0eeaa',\n",
+    "    'TestOptimus.expected_matrix_summary_hash': 'dd513351d4e7688c97f7bf902ba2876f',\n",
+    "    'TestOptimus.expected_picard_metrics_hash': '36101cca60876ab8733729961366322d',\n",
+    "    \"TestOptimus.fastq_inputs\": [\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\n",
+    "      ],\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\n",
+    "      ]\n",
+    "    ],\n",
+    "    \"TestOptimus.whitelist\": \"gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt\",\n",
+    "    \"TestOptimus.tar_star_reference\": \"gs://broad-dsde-mint-dev-teststorage/demo/star.tar\",\n",
+    "    \"TestOptimus.sample_name\": \"pbmc8k_test\",\n",
+    "    \"TestOptimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",\n",
+    "    \"TestOptimus.ref_genome_fasta\": \"gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa\"\n",
+    "}\n",
+    "\n",
+    "wdl = \"TestOptimus.wdl\"\n",
+    "# options_json = \"../adapter_pipelines/Optimus/options.json\"  # no caching \n",
+    "workflow_dependencies = {\n",
+    "    'Optimus.wdl': '../optimus/Optimus.wdl',\n",
+    "    'ValidateOptimus.wdl': 'ValidateOptimus.wdl',\n",
+    "    \"StarAlignBamSingleEnd.wdl\": \"../pipelines/tasks/StarAlignBamSingleEnd.wdl\",\n",
+    "    \"FastqToUBam.wdl\": \"../pipelines/tasks/FastqToUBam.wdl\",\n",
+    "    \"Attach10xBarcodes.wdl\": \"../pipelines/tasks/Attach10xBarcodes.wdl\",\n",
+    "    \"SplitBamByCellBarcode.wdl\": \"../pipelines/tasks/SplitBamByCellBarcode.wdl\",\n",
+    "    \"TagGeneExon.wdl\": \"../pipelines/tasks/TagGeneExon.wdl\",\n",
+    "    \"CorrectUmiMarkDuplicates.wdl\": \"../pipelines/tasks/CorrectUmiMarkDuplicates.wdl\",\n",
+    "    \"CollectMultiplePicardMetrics.wdl\": \"../pipelines/tasks/CollectMultiplePicardMetrics.wdl\",\n",
+    "    \"MergeBam.wdl\": \"../pipelines/tasks/MergeBam.wdl\",\n",
+    "    \"CreateCountMatrix.wdl\": \"../pipelines/tasks/CreateCountMatrix.wdl\",\n",
+    "    \"AlignTagCorrectUmis.wdl\": \"../optimus/AlignTagCorrectUmis.wdl\"    \n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "failing_wf = cwm.Workflow.from_submission(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=failing_inputs_json,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=workflow_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': '6bfd3f85-1af5-4201-8808-faab002a9348', 'status': 'Succeeded'}"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wf.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'calls': {'TestOptimus.checker': [{'attempt': 1,\n",
+       "    'backendLogs': {'log': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/6bfd3f85-1af5-4201-8808-faab002a9348/call-checker/checker.log'},\n",
+       "    'shardIndex': -1,\n",
+       "    'stderr': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/6bfd3f85-1af5-4201-8808-faab002a9348/call-checker/checker-stderr.log',\n",
+       "    'stdout': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/6bfd3f85-1af5-4201-8808-faab002a9348/call-checker/checker-stdout.log'}]},\n",
+       " 'id': '6bfd3f85-1af5-4201-8808-faab002a9348'}"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wf.logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/cromwell_root/exec.sh: line 16: [: too many arguments\r\n",
+      "/cromwell_root/exec.sh: line 21: [: too many arguments\r\n",
+      "/cromwell_root/exec.sh: line 25: [: too many arguments\r\n",
+      "/cromwell_root/exec.sh: line 29: [: too many arguments\r\n",
+      "/cromwell_root/exec.sh: line 33: [: too many arguments\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil cat gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimus/6bfd3f85-1af5-4201-8808-faab002a9348/call-checker/checker-stderr.log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "## Test PR and scientific tests from config files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TestOptimusPR.wdl    dependencies.json\r\n",
+      "ValidateOptimus.wdl  test_inputs.json\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "ls optimus/pr/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PR tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wdl='optimus/pr/TestOptimusPR.wdl'\n",
+    "dependencies='optimus/pr/dependencies.json'\n",
+    "with open(dependencies, 'r') as f:\n",
+    "    dependencies = json.load(f)\n",
+    "inputs='optimus/pr/test_inputs.json'\n",
+    "options='options.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CWM:2017-12-12 09:14:10.224205:creating temporary directory\n",
+      "CWM:2017-12-12 09:14:10.225869:writing dependencies\n",
+      "CWM:2017-12-12 09:14:10.236165:writing wdl\n",
+      "CWM:2017-12-12 09:14:10.236991:running wdltool validate\n",
+      "CWM:2017-12-12 09:14:11.614211:validation successful\n",
+      "CWM:2017-12-12 09:14:12.873793:checking docker image humancellatlas/dropseqtools:1.12... OK.\n",
+      "CWM:2017-12-12 09:14:13.144924:checking docker image humancellatlas/python3-scientific:0.1.5... OK.\n",
+      "CWM:2017-12-12 09:14:13.392328:checking docker image humancellatlas/picard:2.10.10... OK.\n",
+      "CWM:2017-12-12 09:14:13.649861:checking docker image humancellatlas/star:2.5.3a-40ead6e... OK.\n",
+      "CWM:2017-12-12 09:14:13.902457:checking docker image humancellatlas/samtools:1.3.1... OK.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pr_wf = cwm.Workflow.validate(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=inputs,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pr_wf = cwm.Workflow.from_submission(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=inputs,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=dependencies,\n",
+    "    cromwell_server=cromwell_server,\n",
+    "    options_json=options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pr_wf2 = cwm.Workflow.from_submission(\n",
+    "    wdl=wdl,\n",
+    "    inputs_json=inputs,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=dependencies,\n",
+    "    cromwell_server=cromwell_server,\n",
+    "    options_json=options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cromwell_server.metadata(pr_wf.id, open_browser=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'calls': {'TestOptimusPR.checker': [{'attempt': 1,\n",
+       "    'backendLogs': {'log': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/80af9921-f9ad-4b45-b9a5-a1361c9f306b/call-checker/checker.log'},\n",
+       "    'shardIndex': -1,\n",
+       "    'stderr': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/80af9921-f9ad-4b45-b9a5-a1361c9f306b/call-checker/checker-stderr.log',\n",
+       "    'stdout': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/80af9921-f9ad-4b45-b9a5-a1361c9f306b/call-checker/checker-stdout.log'}]},\n",
+       " 'id': '80af9921-f9ad-4b45-b9a5-a1361c9f306b'}"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pr_wf2.logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/d3858e86-9c35-4a36-a110-d02588a99d1e/call-target/Optimus/8232e6a3-6166-4b91-924d-043d84a3e276/call-MergeBam/out_sorted.bam'"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cromwell_server.outputs(pr_wf.metadata['calls']['TestOptimusPR.target'][0]['subWorkflowId']).json()['outputs']['Optimus.bam']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/80af9921-f9ad-4b45-b9a5-a1361c9f306b/call-target/Optimus/8f360c7a-5724-499a-ac8c-d9b243f26ddc/call-CollectMultipleMetrics/pbmc8k_test.tar.gz'"
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cromwell_server.outputs(pr_wf2.metadata['calls']['TestOptimusPR.target'][0]['subWorkflowId']).json()['outputs']['Optimus.picard_metrics']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'calls': {'TestOptimusPR.checker': [{'stdout': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/63b674a5-5deb-4194-b920-c15050eb2b8d/call-checker/checker-stdout.log', 'shardIndex': -1, 'stderr': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/63b674a5-5deb-4194-b920-c15050eb2b8d/call-checker/checker-stderr.log', 'attempt': 1, 'backendLogs': {'log': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/63b674a5-5deb-4194-b920-c15050eb2b8d/call-checker/checker.log'}}]}, 'id': '63b674a5-5deb-4194-b920-c15050eb2b8d'}\n",
+      "{'calls': {'TestOptimusPR.checker': [{'stdout': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/bde37bd9-b81d-4c96-9df8-5b7035c062cc/call-checker/checker-stdout.log', 'shardIndex': -1, 'stderr': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/bde37bd9-b81d-4c96-9df8-5b7035c062cc/call-checker/checker-stderr.log', 'attempt': 1, 'backendLogs': {'log': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/bde37bd9-b81d-4c96-9df8-5b7035c062cc/call-checker/checker.log'}}]}, 'id': 'bde37bd9-b81d-4c96-9df8-5b7035c062cc'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pr_wf.logs)\n",
+    "print(pr_wf2.logs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bam_hash (8c03262b5bd383abd237e5c1dab202bd) did not match expected hash (b58ad655d246e0c50a12d492bf4567dd)\r\n",
+      "picard_metrics_hash (7b7be5c9a2236920ca09f05811dca6d5) did not match expected hash (3a1d63932057b18ae8eb2463b1d5236e)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil cat gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/bde37bd9-b81d-4c96-9df8-5b7035c062cc/call-checker/checker-stderr.log"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bam_hash (8c03262b5bd383abd237e5c1dab202bd) did not match expected hash (b58ad655d246e0c50a12d492bf4567dd)\r\n",
+      "picard_metrics_hash (7b7be5c9a2236920ca09f05811dca6d5) did not match expected hash (3a1d63932057b18ae8eb2463b1d5236e)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!gsutil cat gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/TestOptimusPR/63b674a5-5deb-4194-b920-c15050eb2b8d/call-checker/checker-stderr.log"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'bde37bd9-b81d-4c96-9df8-5b7035c062cc', 'status': 'Failed'}"
+      ]
+     },
+     "execution_count": 143,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# when this one fails, update the @RG header\n",
+    "pr_wf2.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': '63b674a5-5deb-4194-b920-c15050eb2b8d', 'status': 'Running'}"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# when this one fails, update the @RG header\n",
+    "pr_wf.status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scientific tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sci_wdl='optimus/scientific/TestOptimusScientific.wdl'\n",
+    "sci_dependencies='optimus/scientific/dependencies.json'\n",
+    "with open(sci_dependencies, 'r') as f:\n",
+    "    sci_dependencies = json.load(f)\n",
+    "sci_inputs='optimus/scientific/test_inputs.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CWM:2017-12-11 19:17:32.595019:creating temporary directory\n",
+      "CWM:2017-12-11 19:17:32.596616:writing dependencies\n",
+      "CWM:2017-12-11 19:17:32.606036:writing wdl\n",
+      "CWM:2017-12-11 19:17:32.606800:running wdltool validate\n",
+      "CWM:2017-12-11 19:17:33.811435:validation successful\n",
+      "CWM:2017-12-11 19:17:34.562100:checking docker image humancellatlas/dropseqtools:1.12... OK.\n",
+      "CWM:2017-12-11 19:17:35.050001:checking docker image humancellatlas/python3-scientific:0.1.5... OK.\n",
+      "CWM:2017-12-11 19:17:35.588630:checking docker image humancellatlas/picard:2.10.10... OK.\n",
+      "CWM:2017-12-11 19:17:36.142646:checking docker image humancellatlas/star:2.5.3a-40ead6e... OK.\n",
+      "CWM:2017-12-11 19:17:36.779175:checking docker image humancellatlas/samtools:1.3.1... OK.\n"
+     ]
+    }
+   ],
+   "source": [
+    "sci_wf = cwm.Workflow.validate(\n",
+    "    wdl=sci_wdl,\n",
+    "    inputs_json=sci_inputs,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=sci_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sci_wf = cwm.Workflow.from_submission(\n",
+    "    wdl=sci_wdl,\n",
+    "    inputs_json=sci_inputs,\n",
+    "    storage_client=storage_client,\n",
+    "    workflow_dependencies=sci_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': '91fef86e-7b1b-4260-bc09-cc357a730634', 'status': 'Failed'}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sci_wf.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sci_wf.timing()\n",
+    "cromwell_server.metadata(sci_wf.id, open_browser=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  },
+  "nav_menu": {},
+  "toc": {
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 6,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test/trigger_test.sh
+++ b/test/trigger_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # NOTE: this script will execute from the repository root when called on jenkins
 
 VAULT_TOKEN=$1
@@ -18,7 +20,7 @@ CROMWELL_SECRETS="${WD}/test/cromwell-secrets.json"
 CROMWELL_USER=$(cat "${CROMWELL_SECRETS}" | jq -r .cromwell_user)
 CROMWELL_PASSWORD=$(cat "${CROMWELL_SECRETS}" | jq -r .cromwell_password)
 
-OPTIONS_FILE="https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/options.json"
+OPTIONS_FILE="https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/test/options.json"
 CROMWELL_URL="https://cromwell.mint-dev.broadinstitute.org"
 
 echo "Running test"

--- a/test/trigger_test.sh
+++ b/test/trigger_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# NOTE: this script will execute from the repository root when called on jenkins
+
+VAULT_TOKEN=$1
+INPUTS_JSON=$2
+WDL_FILE=$3
+DEPENDENCIES_JSON=$4
+WD=$(pwd)
+echo $(ls)
+echo ${WD}
+
+echo "Rendering templates"
+bash ${WD}/test/config/render-ctmpls.sh "dev" "${VAULT_TOKEN}"
+
+echo "Setting Cromwell environmental variables"
+CROMWELL_SECRETS="${WD}/test/cromwell-secrets.json"
+CROMWELL_USER=$(cat "${CROMWELL_SECRETS}" | jq -r .cromwell_user)
+CROMWELL_PASSWORD=$(cat "${CROMWELL_SECRETS}" | jq -r .cromwell_password)
+
+OPTIONS_FILE="https://raw.githubusercontent.com/HumanCellAtlas/skylab/ajc-pr-test/test/options.json"
+CROMWELL_URL="https://cromwell.mint-dev.broadinstitute.org"
+
+echo "Running test"
+docker run --rm \
+  -v ${WD}/test:/test \
+  humancellatlas/cromwell-tools:1.0.1 \
+  /test/test_cromwell_workflow.sh \
+    "${CROMWELL_USER}" \
+    "${CROMWELL_PASSWORD}" \
+    "${CROMWELL_URL}" \
+    "${INPUTS_JSON}" \
+    "${WDL_FILE}" \
+    "${OPTIONS_FILE}" \
+    "${DEPENDENCIES_JSON}"


### PR DESCRIPTION
**This PR adds scientific and PR testing infrastructure to Skylab.**

Both tests share the same infrastructure, and follow the portability spec; the WDLs in this PR represent a cromwell test case for the [portability test](https://docs.google.com/document/d/1ghLoHMbKOPsndA1WgdSAHm5X82p86ryLBiAt1hz6HuI/edit); they are just missing a docker environment to run the WDLs in. 

The PR test is designed to answer the question: "did my changes result in any change to the outputs of my pipeline?"

The scientific test is designed to answer the question: "Is the pipeline performing within an expected range of scientific outputs?"

**Testing Logic & Files**
All files added in this PR are contained within the test directory. 
- `tests/trigger_test.sh` triggers tests to run within the `humancellatlas/cromwell-tools` docker. This is the test called by Jenkins, and it takes parameters: inputs, wdl, and dependencies. It is designed to trigger tests in the form of WDL workflows. 
- `tests/test_cromwell_workflow.sh` is called by `tests/trigger_test.sh` within the cromwell-tools docker. It calls the provided wdl, waits for it to finish, and checks it's success state. 
- The scientific and PR tests both contain an "infrastructure wdl" which is composed of two parts:
  - The pipeline workflow, which is imported and run to completion without call caching. 
  - The checker workflow, which, given the outputs of the just-run pipeline, tests them either against the expected outputs (PR) or a range of acceptable outputs (scientific) 

The tests are designed so that any failure results in `exit 1` within the workflow, after the reason is logged to stderr. If a workflow fails due to a result not matching expectations, the result will be logged in the stderr produced by the checker task. If a workflow fails due to not running properly, the user will need to go find the part of the workflow that failed. The jenkins job and cromwell backend will both log the workflow ID so that it is easy to go back and find the failed workflow. 

**Updating workflows that result in scientific changes:**
In the event that a PR produces a desirable scientific change, the PR test will fail. In order to ensure that future PRs test against the correct "expected values", the test inputs must be updated to reflect the success state of the incoming pipeline. For optimus, this means updating the md5 hashes corresponding to the new output files, which are found in: 
`test/optimus/pr/test_inputs.json` (PR)
`test/optimus/scientific/test_inputs.json` (scientific)

More complex tests may require different inputs, but the expected values should always be parameterized in the `test_inputs.json` files to facilitate easy updating. 

**This branch currently fails PR tests**
The final commit in this PR causes the tests to fail, as it updates the targets to master (which don't exist yet). The previous commit resulted in a successful test.

**This PR adds a few scientific modifications to Optimus**
It changes the way alignment is done in order to output a bam file that is deterministic, and identical after sorting & filtering run headers. 