### PR TITLE
Ajc scale optimus

### DIFF
--- a/optimus/Optimus.wdl
+++ b/optimus/Optimus.wdl
@@ -50,26 +50,26 @@ workflow Optimus {
     }
   }
 
-  call merge.MergeSortBam {
+  call merge.MergeSortBamFiles {
     input:
       bam_inputs = AlignTagCorrectUmis.bam_outputs
   }
 
   call count.DropSeqToolsDigitalExpression {
     input:
-      bam_input = MergeSortBam.bam_output,
+      bam_input = MergeSortBamFiles.output_bam,
       whitelist = whitelist
   }
 
   call collect.CollectMultipleMetrics {
     input:
-      aligned_bam = MergeSortBam.bam_output,
+      aligned_bam = MergeSortBamFiles.output_bam,
       ref_genome_fasta = ref_genome_fasta,
       output_filename = sample_id
   }
 
   output {
-      File bam = MergeSortBam.bam_output
+      File bam = MergeSortBamFiles.output_bam
       File matrix = DropSeqToolsDigitalExpression.matrix_output
       File matrix_summary = DropSeqToolsDigitalExpression.matrix_summary
       Array[Array[File]] tag_gene_exon_log = AlignTagCorrectUmis.tag_gene_exon_log

--- a/optimus/test_optimus.ipynb
+++ b/optimus/test_optimus.ipynb
@@ -1,18 +1,8 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Load Libraries"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -28,35 +18,53 @@
     "with open(os.path.expanduser('~/.ssh/mint_cromwell_config.json')) as f:\n",
     "    cromwell_server = cwm.Cromwell(**json.load(f))\n",
     "\n",
-    "storage_client = storage.Client(project='broad-dsde-mint-dev')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Define Testing Inputs"
+    "storage_client = storage.Client(project='broad-dsde-mint-dev')\n",
+    "\n",
+    "os.environ['wdltool'] = '/Users/ajc/google_drive/software/wdltool-0.14.jar'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"Optimus.fastq_inputs\": [\r\n",
+      "    [\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\r\n",
+      "    ],\r\n",
+      "    [\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\r\n",
+      "      \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\r\n",
+      "    ]\r\n",
+      "  ],\r\n",
+      "  \"Optimus.whitelist\": \"gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt\",\r\n",
+      "  \"Optimus.tar_star_reference\": \"gs://broad-dsde-mint-dev-teststorage/demo/star.tar\",\r\n",
+      "  \"Optimus.sample_id\": \"pbmc8k_test\",\r\n",
+      "  \"Optimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",\r\n",
+      "  \"Optimus.ref_genome_fasta\": \"gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa\"\r\n",
+      "}\r\n"
+     ]
+    }
+   ],
    "source": [
-    "os.environ['wdltool'] = '/Users/carra1/google_drive/software/wdltool-0.14.jar'"
+    "cat example_test_inputs.json"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -66,21 +74,28 @@
    "source": [
     "inputs_json = {\n",
     "    \"Optimus.fastq_inputs\": [\n",
-    "        [\"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\", \n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"],\n",
-    "        [\"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\", \n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"],\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"\n",
+    "      ],\n",
+    "      [\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R1_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R2_001.fastq.gz\",\n",
+    "          \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_I1_001.fastq.gz\"\n",
+    "      ]\n",
     "    ],\n",
     "    \"Optimus.whitelist\": \"gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt\",\n",
     "    \"Optimus.tar_star_reference\": \"gs://broad-dsde-mint-dev-teststorage/demo/star.tar\",\n",
     "    \"Optimus.sample_id\": \"pbmc8k_test\",\n",
-    "    \"Optimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",  # \"gs://broad-dsde-mint-dev-teststorage/demo/gencodev19_chr21.gtf\",\n",
+    "    \"Optimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",\n",
     "    \"Optimus.ref_genome_fasta\": \"gs://broad-dsde-mint-dev-teststorage/demo/chr21.fa\"\n",
     "}\n",
     "\n",
-    "dependencies_json = {\n",
+    "wdl = \"Optimus.wdl\"\n",
+    "\n",
+    "workflow_dependencies = {\n",
+    "    'Optimus.wdl': '../optimus/Optimus.wdl',\n",
     "    \"StarAlignBamSingleEnd.wdl\": \"../pipelines/tasks/StarAlignBamSingleEnd.wdl\",\n",
     "    \"FastqToUBam.wdl\": \"../pipelines/tasks/FastqToUBam.wdl\",\n",
     "    \"Attach10xBarcodes.wdl\": \"../pipelines/tasks/Attach10xBarcodes.wdl\",\n",
@@ -88,41 +103,15 @@
     "    \"TagGeneExon.wdl\": \"../pipelines/tasks/TagGeneExon.wdl\",\n",
     "    \"CorrectUmiMarkDuplicates.wdl\": \"../pipelines/tasks/CorrectUmiMarkDuplicates.wdl\",\n",
     "    \"CollectMultiplePicardMetrics.wdl\": \"../pipelines/tasks/CollectMultiplePicardMetrics.wdl\",\n",
-    "    \"MergeBam.wdl\": \"../pipelines/tasks/MergeBam.wdl\",\n",
+    "    \"MergeSortBam.wdl\": \"../pipelines/tasks/MergeSortBam.wdl\",\n",
     "    \"CreateCountMatrix.wdl\": \"../pipelines/tasks/CreateCountMatrix.wdl\",\n",
-    "    \"AlignTagCorrectUmis.wdl\": \"AlignTagCorrectUmis.wdl\"\n",
-    "}\n",
-    "\n",
-    "wdl = \"Optimus.wdl\""
+    "    \"AlignTagCorrectUmis.wdl\": \"../optimus/AlignTagCorrectUmis.wdl\"    \n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "with open('example_test_inputs.json', 'w') as f:\n",
-    "    json.dump(inputs_json, f)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Validate & Run WDL"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 39,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -133,16 +122,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CWM:2017-11-30 18:08:33.237760:creating temporary directory\n",
-      "CWM:2017-11-30 18:08:33.238304:writing dependencies\n",
-      "CWM:2017-11-30 18:08:33.253327:writing wdl\n",
-      "CWM:2017-11-30 18:08:33.254993:running wdltool validate\n",
-      "CWM:2017-11-30 18:08:34.714824:validation successful\n",
-      "CWM:2017-11-30 18:08:40.115040:checking docker image humancellatlas/dropseqtools:1.12... OK.\n",
-      "CWM:2017-11-30 18:09:02.514529:checking docker image humancellatlas/samtools:1.3.1... OK.\n",
-      "CWM:2017-11-30 18:09:09.818599:checking docker image humancellatlas/picard:2.10.10... OK.\n",
-      "CWM:2017-11-30 18:09:21.088804:checking docker image humancellatlas/star:2.5.3a-40ead6e... OK.\n",
-      "CWM:2017-11-30 18:09:22.741164:checking docker image humancellatlas/python3-scientific:0.1.3... OK.\n"
+      "CWM:2018-01-08 20:07:42.953779:creating temporary directory\n",
+      "CWM:2018-01-08 20:07:42.954540:writing dependencies\n",
+      "CWM:2018-01-08 20:07:42.968711:writing wdl\n",
+      "CWM:2018-01-08 20:07:42.969804:running wdltool validate\n",
+      "Error: Unable to access jarfile /Users/ajc/google_drive/software/wdltool-0.14.jar\n",
+      "\n",
+      "CWM:2018-01-08 20:07:43.482615:checking docker image humancellatlas/picard:2.10.10... OK.\n",
+      "CWM:2018-01-08 20:07:43.777050:checking docker image humancellatlas/dropseqtools:1.12... OK.\n",
+      "CWM:2018-01-08 20:07:45.049217:checking docker image humancellatlas/samtools:1.3.1... OK.\n",
+      "CWM:2018-01-08 20:07:45.765581:checking docker image humancellatlas/python3-scientific:0.1.5... OK.\n",
+      "CWM:2018-01-08 20:07:45.996618:checking docker image us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.3-1513176735... not found. Is image private?\n",
+      "CWM:2018-01-08 20:07:46.299912:checking docker image humancellatlas/star:2.5.3a-40ead6e... OK.\n"
      ]
     }
    ],
@@ -151,16 +142,15 @@
     "    wdl=wdl,\n",
     "    inputs_json=inputs_json,\n",
     "    storage_client=storage_client,\n",
-    "    workflow_dependencies=dependencies_json,\n",
-    "    cromwell_server=cromwell_server\n",
-    ")"
+    "    workflow_dependencies=workflow_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 40,
    "metadata": {
-    "collapsed": false,
+    "collapsed": true,
     "deletable": true,
     "editable": true
    },
@@ -170,24 +160,13 @@
     "    wdl=wdl,\n",
     "    inputs_json=inputs_json,\n",
     "    storage_client=storage_client,\n",
-    "    workflow_dependencies=dependencies_json,\n",
-    "    cromwell_server=cromwell_server\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Display the status and the completed run ID"
+    "    workflow_dependencies=workflow_dependencies,\n",
+    "    cromwell_server=cromwell_server)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 46,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -197,10 +176,10 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'f89c4b63-6511-42b9-8fbe-3124728cc7c1', 'status': 'Succeeded'}"
+       "{'id': 'fb314e86-5943-41cb-9ec9-361ed92f4833', 'status': 'Succeeded'}"
       ]
      },
-     "execution_count": 232,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,20 +189,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 44,
    "metadata": {
+    "collapsed": false,
     "deletable": true,
     "editable": true
-   },
-   "source": [
-    "Display the outputs of the rMVP"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 228,
-   "metadata": {
-    "collapsed": false
    },
    "outputs": [
     {
@@ -232,7 +203,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 228,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -243,124 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'c98322d7-406d-4e3f-96c8-e2bd1429e645',\n",
-       " 'outputs': {'Optimus.bam': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-MergeBam/out.bam',\n",
-       "  'Optimus.duplicate_metrics': [['gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-AlignTagCorrectUmis/shard-0/AlignTagCorrectUmis/d250b98d-a2f0-4b19-be86-e347bd076a5f/call-CorrectUmiMarkDuplicates/shard-0/duplicate_metrics.txt']],\n",
-       "  'Optimus.matrix': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-DropSeqToolsDigitalExpression/digital_expression.txt.gz',\n",
-       "  'Optimus.matrix_summary': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-DropSeqToolsDigitalExpression/digital_expression_summary.txt',\n",
-       "  'Optimus.picard_metrics': 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-CollectMultipleMetrics/pbmc8k_test.tar.gz',\n",
-       "  'Optimus.tag_gene_exon_log': [['gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-AlignTagCorrectUmis/shard-0/AlignTagCorrectUmis/d250b98d-a2f0-4b19-be86-e347bd076a5f/call-TagGeneExon/shard-0/gene_exon_tag_summary.log']],\n",
-       "  'Optimus.umi_metrics': [['gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/Optimus/c98322d7-406d-4e3f-96c8-e2bd1429e645/call-AlignTagCorrectUmis/shard-0/AlignTagCorrectUmis/d250b98d-a2f0-4b19-be86-e347bd076a5f/call-CorrectUmiMarkDuplicates/shard-0/umi_metrics.txt']]}}"
-      ]
-     },
-     "execution_count": 180,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "wf.outputs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 210,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "with open('example_test_outputs.json', 'w') as f:\n",
-    "    json.dump(wf.outputs, f)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Open up the completed timing graph and the complete run metadata"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 213,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 213,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "wf.timing()\n",
-    "cromwell_server.metadata(wf.id, open_browser=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Test at Scale"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 199,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/metadata.json\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_I1_001.fastq.gz\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R1_001.fastq.gz\r\n",
-      "gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R2_001.fastq.gz\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!gsutil ls gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -368,89 +222,7 @@
    },
    "outputs": [],
    "source": [
-    "scale_inputs_json = {\n",
-    "    \"Optimus.fastq_inputs\": [\n",
-    "        [\"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz\", \n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz\",\n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz\"],\n",
-    "        [\"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R1_001.fastq.gz\", \n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_R2_001.fastq.gz\",\n",
-    "         \"gs://broad-dsde-mint-dev-teststorage/10x/pbmc8k/fastqs/pbmc8k_S1_L008_I1_001.fastq.gz\"],\n",
-    "    ],\n",
-    "    \"Optimus.whitelist\": \"gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt\",\n",
-    "    \"Optimus.tar_star_reference\": \"gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/star_hg19_gencode_v19.tar\",\n",
-    "    \"Optimus.sample_name\": \"pbmc8k_Optimus_test\",\n",
-    "    \"Optimus.annotations_gtf\": \"gs://broad-dsde-mint-dev-teststorage/reference/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz\",  # \"gs://broad-dsde-mint-dev-teststorage/demo/gencodev19_chr21.gtf\",\n",
-    "    \"Optimus.ref_genome_fasta\": \"gs://broad-dsde-mint-dev-teststorage/reference/Hg19_kco/Hg19.fa\",\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 207,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "scale_wf = cwm.Workflow.from_submission(\n",
-    "    wdl=wdl,\n",
-    "    inputs_json=scale_inputs_json,\n",
-    "    storage_client=storage_client,\n",
-    "    workflow_dependencies=dependencies_json,\n",
-    "    cromwell_server=cromwell_server\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 202,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': '7533b502-34ba-4175-832b-d7031e694248', 'status': 'Running'}"
-      ]
-     },
-     "execution_count": 202,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "scale_wf.status"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 214,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 214,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "scale_wf.timing()\n",
-    "cromwell_server.metadata(scale_wf.id, open_browser=True)"
+    "wf.timing()"
    ]
   },
   {

--- a/pipelines/tasks/Attach10xBarcodes.wdl
+++ b/pipelines/tasks/Attach10xBarcodes.wdl
@@ -10,7 +10,7 @@ task Attach10xBarcodes {
   # estimate disk requirements
   Float bam_size = size(u2, "G")
   Float fastq_size = size(r1, "G") + size(i1, "G")
-  Int estimated_required_disk = ceil(fastq_size + bam_size * 2.2)
+  Int estimated_required_disk = ceil(fastq_size + bam_size * 2.5)
 
   command {
     Attach10xBarcodes \

--- a/pipelines/tasks/CollectMultiplePicardMetrics.wdl
+++ b/pipelines/tasks/CollectMultiplePicardMetrics.wdl
@@ -3,6 +3,7 @@ task CollectMultipleMetrics {
   File aligned_bam
   File ref_genome_fasta
   String output_filename
+  Int estimated_required_disks = ceil((size(aligned_bam, "G") + size(ref_genome_fasta, "G")) * 1.2)
 
   command {
     java -Xmx3g -jar /usr/picard/picard.jar CollectMultipleMetrics \
@@ -20,7 +21,7 @@ task CollectMultipleMetrics {
   runtime {
     docker:"humancellatlas/picard:2.10.10"
     memory:"3.75 GB"
-    disks: "local-disk 10 HDD"
+    disks: "local-disk ${estimated_required_disks} HDD"
   }
   output {
     File alignment_metrics = "${output_filename}.tar.gz"

--- a/pipelines/tasks/CorrectUmiMarkDuplicates.wdl
+++ b/pipelines/tasks/CorrectUmiMarkDuplicates.wdl
@@ -1,14 +1,19 @@
 
 task CorrectUmiMarkDuplicates {
   File bam_input
+  # mark duplicates swaps a large amount of data to disk, has high disk requirements.
+  Int estimated_required_disk = ceil(size(bam_input, "G") * 6)
 
   command {
-    java -Xmx3g -jar /usr/picard/picard.jar SortSam \
+    java -Xmx7g -jar /usr/picard/picard.jar SortSam \
       SORT_ORDER=coordinate \
       I=${bam_input} \
       O=sorted.bam
 
-    java -Xmx3g -jar /usr/picard/picard.jar UmiAwareMarkDuplicatesWithMateCigar \
+    # recover disk space
+    rm ${bam_input}
+
+    java -Xmx7g -jar /usr/picard/picard.jar UmiAwareMarkDuplicatesWithMateCigar \
       MAX_EDIT_DISTANCE_TO_JOIN=1 \
       UMI_METRICS_FILE=umi_metrics.txt \
       UMI_TAG_NAME=UR \
@@ -22,8 +27,8 @@ task CorrectUmiMarkDuplicates {
   runtime {
     docker: "humancellatlas/picard:2.10.10"
     cpu: 1
-    memory: "3.75 GB"
-    disks: "local-disk 100 HDD"
+    memory: "7.5 GB"
+    disks: "local-disk ${estimated_required_disk} HDD"
   }
   
   output {

--- a/pipelines/tasks/CreateCountMatrix.wdl
+++ b/pipelines/tasks/CreateCountMatrix.wdl
@@ -1,9 +1,8 @@
-# AUTHOR: 
-# Created on 2017/11/22
 
 task DropSeqToolsDigitalExpression {
   File bam_input
   File whitelist
+  Int estimated_required_disk = ceil((size(bam_input, "G") + size(whitelist, "G")) * 4.0) + 1
 
   command {
     DigitalExpression \
@@ -20,8 +19,8 @@ task DropSeqToolsDigitalExpression {
   runtime {
     docker: "humancellatlas/dropseqtools:1.12"
     cpu: 1
-    memory: "3.75 GB"
-    disks: "local-disk 100 HDD"
+    memory: "7.5 GB"
+    disks: "local-disk ${estimated_required_disk} HDD"
   }
   
   output {

--- a/pipelines/tasks/SplitBamByCellBarcode.wdl
+++ b/pipelines/tasks/SplitBamByCellBarcode.wdl
@@ -2,6 +2,7 @@
 task SplitBamByCellBarcode {
   File bam_input
   Float size_in_mb = 1024.0
+  Int estimated_required_disk = ceil(size(bam_input, "G") * 2.2)
 
   command {
     SplitBam \
@@ -15,7 +16,7 @@ task SplitBamByCellBarcode {
     docker: "humancellatlas/python3-scientific:0.1.5"
     cpu: 1
     memory: "3.75 GB"
-    disks: "local-disk 100 HDD"
+    disks: "local-disk ${estimated_required_disk} HDD"
   }
   
   output {

--- a/pipelines/tasks/TagGeneExon.wdl
+++ b/pipelines/tasks/TagGeneExon.wdl
@@ -2,6 +2,7 @@
 task TagGeneExon {
   File bam_input
   File annotations_gtf
+  Int estimated_required_disk = ceil((size(bam_input, "G") + size(annotations_gtf, "G")) * 2)
   
   command {
     TagReadWithGeneExon \
@@ -16,7 +17,7 @@ task TagGeneExon {
     docker: "humancellatlas/dropseqtools:1.12"
     cpu: 1
     memory: "3.75 GB"
-    disks: "local-disk 100 HDD"
+    disks: "local-disk ${estimated_required_disk} HDD"
   }
   
   output {

--- a/test/optimus/pr/test_inputs.json
+++ b/test/optimus/pr/test_inputs.json
@@ -1,5 +1,5 @@
 {
-  "TestOptimusPR.expected_bam_hash": "8c03262b5bd383abd237e5c1dab202bd",
+  "TestOptimusPR.expected_bam_hash": "f944c8d26ed178e5cbcc96d75f8f380f",
   "TestOptimusPR.expected_matrix_hash": "69f3be6085e0c5f694b3cfa877b0eeaa",
   "TestOptimusPR.expected_matrix_summary_hash": "dd513351d4e7688c97f7bf902ba2876f",
   "TestOptimusPR.expected_picard_metrics_hash": "7b7be5c9a2236920ca09f05811dca6d5",


### PR DESCRIPTION
This PR allows Optimus to run on scale-size data (pbmc8k)

It: 
- removes samtools, and replaces it with picard (solve weird merge problems)
- adds tested memory and disk size requirements to each task. 