### PR TITLE
Add a portability test of SmartSeq2 and Optimus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,9 @@ jobs:
             - image: circleci/python:3.6.1
         steps:
             - checkout
-            - run: echo "hello world"
+            - run:
+                command: |
+                    python3 -m venv venv
+                    . venv/bin/activate
+                    pip install requests
+                    python test/run_portability_test.py --test-directories test/smartseq2_single_sample/pr/ test/optimus/pr

--- a/test/run_portability_test.py
+++ b/test/run_portability_test.py
@@ -1,0 +1,199 @@
+"""Runs a single portability test from a test directory."""
+
+import argparse
+import datetime
+import glob
+import json
+import os
+import sys
+import time
+
+import requests
+
+# This is what we need to find in a test directory. I guess we'll glob the PR
+# test WDL itself since it's named after the pipeline.
+TEST_DIR_LAYOUT = {
+    "inputs": "test_inputs.json",
+    "dependencies": "dependencies.json",
+    "test": "*PR.wdl"
+}
+
+class TestFailure(Exception):
+    """Error for a test that fails its portability test."""
+    pass
+
+class TestDefinitionError(Exception):
+    """Error for malformed test directory."""
+    pass
+
+class TestEnvironmentError(Exception):
+    """Error for malformed test environment."""
+    pass
+
+def gather_test_inputs(test_dir):
+    """Walk through the test directory, finding files and dependencies needed
+    to submit a portability test.
+
+    Raise a TestDefinitionError if anything goes wrong.
+    """
+
+    errors = []
+
+    # Test WDL
+    wdl_glob = os.path.join(test_dir, TEST_DIR_LAYOUT["test"])
+    wdl_paths = glob.glob(wdl_glob)
+    if not wdl_paths:
+        errors.append("Test definition WDL not found.")
+    if len(wdl_paths) > 1:
+        errors.append("Multiple candidate test WDLs found: {}".format(wdl_paths))
+
+    try:
+        test_wdl_string = open(wdl_paths[0]).read()
+    except IOError:
+        test_wdl_string = None
+        errors.append("Test WDL {} could not be read".format(wdl_paths[0]))
+
+    # Test inputs
+    try:
+        inputs_json_path = os.path.join(test_dir, TEST_DIR_LAYOUT["inputs"])
+        inputs_json_string = open(inputs_json_path).read()
+    except IOError:
+        inputs_json_string = None
+        errors.append("Inputs JSON {} could not be read".format(inputs_json_path))
+
+    # Dependencies
+
+    # First try to load the dependency JSON itself
+    try:
+        dependencies_json_path = os.path.join(test_dir, TEST_DIR_LAYOUT["dependencies"])
+        dependencies_json_string = open(dependencies_json_path).read()
+    except IOError:
+        dependencies_json_string = None
+        errors.append("Dependencies JSON {} could not be read".format(dependencies_json_path))
+
+    # Now iterate over the dependencies and load the files.
+    loaded_dependencies = []
+    dependencies_dict = json.loads(dependencies_json_string)
+
+    for key, value in dependencies_dict.items():
+        try:
+            loaded_dependencies.append({
+                "name": key,
+                "code": open(value).read()
+            })
+        except IOError:
+            errors.append("Could not read dependency {}".format(value))
+
+    if errors:
+        for error in errors:
+            sys.stderr.write(error + "\n")
+        raise TestDefinitionError(errors)
+
+    return {
+        "workflow_descriptor": test_wdl_string,
+        "workflow_params": inputs_json_string,
+        "workflow_dependencies": loaded_dependencies
+        }
+
+# These are the environment variables we're expecting to be able to submit a
+# portability test.
+ENV_VARIABLES = {
+    "portability_service_url": os.environ.get("PORTABILITY_SERVICE_URL"),
+    "portability_service_headers": os.environ.get("PORTABILITY_SERVICE_HEADERS")
+}
+
+def verify_environment_variables():
+    """Check that required environment variables are defined."""
+
+    errors = []
+
+    for key, value in ENV_VARIABLES.items():
+        if not value:
+            errors.append("Environment variable {} is undefined".format(key.upper()))
+    if errors:
+        for error in errors:
+            sys.stderr.write(error + "\n")
+        raise TestEnvironmentError(errors)
+
+def submit_portability_test(test_inputs):
+    """Submit the portability to the service and return the test's id."""
+
+    service_headers = json.loads(ENV_VARIABLES["portability_service_headers"])
+    test_endpoint = ENV_VARIABLES["portability_service_url"] + "/portability_tests"
+    response = requests.post(
+        test_endpoint,
+        headers=service_headers,
+        json=test_inputs)
+
+    print("Portability service response:\n{}".format(
+        json.dumps(json.loads(response.text), indent=4)), flush=True)
+
+    test_id = json.loads(response.text)["test_id"]
+
+    return test_id
+
+def print_test_states(test_states):
+    """Print the states of tests."""
+    print("{:%Y-%m-%dT%H:%M:%SZ}".format(datetime.datetime.utcnow()), flush=True)
+    for test_name, test_state in test_states.items():
+        print("TEST:{} STATE:{}".format(test_name, test_state), flush=True)
+
+def monitor_tests(test_ids):
+    """Check the status of tests until they all either fail or succeed. If any fail, raise
+    TestFailure, and if they all succeed, return successfully.
+    """
+
+    service_headers = json.loads(ENV_VARIABLES["portability_service_headers"])
+
+    terminal_tests = {}
+    while True:
+        time.sleep(120)
+
+        test_states = {}
+
+        for test_name, test_id in test_ids.items():
+
+            if test_name in terminal_tests:
+                test_states[test_name] = terminal_tests[test_name]
+                continue
+
+            status_endpoint = ENV_VARIABLES["portability_service_url"]  + "/portability_tests/" + \
+                test_id + "/status"
+
+            response = requests.get(status_endpoint, headers=service_headers)
+            test_state = json.loads(response.text)["state"]
+            test_states[test_name] = test_state
+
+        print_test_states(test_states)
+
+        for test_name, test_state in test_states.items():
+            if test_state in ("Failed", "Succeeded"):
+                terminal_tests[test_name] = test_state
+
+        if len(terminal_tests) == len(test_ids):
+            break
+
+    if not all(k == "Succeeded" for k in terminal_tests.values()):
+        raise TestFailure()
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-directories", required=True, nargs='+')
+    args = parser.parse_args()
+
+    verify_environment_variables()
+
+    tests_inputs = {}
+    for test_directory in args.test_directories:
+        test_inputs = gather_test_inputs(test_directory)
+        tests_inputs[test_directory] = test_inputs
+
+    test_ids = {}
+    for test_dir, test_inputs in tests_inputs.items():
+        test_id = submit_portability_test(test_inputs)
+        test_ids[test_dir] = test_id
+
+    monitor_tests(test_ids)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is not necessarily for merging (though it could be merged!)

This is a portability test of the SmartSeq2 pipeline. It uses travis to submit a portability test workflow to an externally-hosted portability testing service. That service in turn distributes the test workflow to different environments and reports on the success or failure of the workflow in those environments. The service code is in www.github.com/HumanCellAtlas/portability.

There are a few points here to for the Mint team to consider:
1. Skylab is being reorganized, how should portability test code fit with that?
2. This PR puts the tests in a json file with a (hopefully) straightforward structure. Does that work for defining the tests?
3. The current SS2 test finishes in ~20 minutes even on a 2 core machine. How long will future portability tests take? This will determine when/if we move off of travis, but more importantly it determines how these tests fit with developer practices. 
4. How do we host test input files? This involved me copying them to AWS and making them public. But that's not a real solution.