### PR TITLE
Fix path to cromwell secret

### DIFF
--- a/test/config/cromwell-secrets.json.ctmpl
+++ b/test/config/cromwell-secrets.json.ctmpl
@@ -1,5 +1,5 @@
 {{with $environment := env "ENVIRONMENT"}}
-{{with $cromwellSecrets := vault (printf "secret/dsde/mint/%s/cromwell/cromwell-login" $environment)}}
+{{with $cromwellSecrets := vault (printf "secret/dsde/mint/%s/common/htpasswd" $environment)}}
 {
   "cromwell_user": "{{$cromwellSecrets.Data.cromwell_user}}",
   "cromwell_password": "{{$cromwellSecrets.Data.cromwell_password}}"


### PR DESCRIPTION
The Cromwell password is stored in several vault paths, which should be consolidated. Update the path used here to the same path used by cromwell. 