### PR TITLE
Ajc remove i7 requirement

### DIFF
--- a/library/tasks/Attach10xBarcodes.wdl
+++ b/library/tasks/Attach10xBarcodes.wdl
@@ -3,26 +3,26 @@ task Attach10xBarcodes {
   # attaches barcodes found in r1 and i1
 
   File r1  # forward fastq file; contains umi, cell barcode
-  File i1  # index fastq file; contains sample barcode
   File u2  # reverse bam file; contains alignable genomic information
+  File? i1  # optional, index fastq file; contains sample barcode
   File whitelist  # 10x genomics cell barcode whitelist for 10x V2
 
   # estimate disk requirements
   Float bam_size = size(u2, "G")
-  Float fastq_size = size(r1, "G") + size(i1, "G")
+  Float fastq_size = size(r1, "G")  + if (defined(i1)) then size(i1, "G") else 0
   Int estimated_required_disk = ceil(fastq_size + bam_size * 2.5)
 
   command {
     Attach10xBarcodes \
       --r1 "${r1}" \
-      --i1 "${i1}" \
+      ${"--i1 " + i1} \
       --u2 "${u2}" \
       --output-bamfile barcoded.bam \
       --whitelist "${whitelist}"
   }
   
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.5"
+    docker: "quay.io/humancellatlas/secondary-analysis-sctools:0.1.6"
     cpu: 2
     memory: "7.5 GB"
     disks: "local-disk ${estimated_required_disk} HDD"

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -12,34 +12,60 @@ import "AlignTagCorrectUmis.wdl" as AlignTagCorrectUmis
 # format.
 workflow Optimus {
 
-  Array[Array[File]] fastq_inputs  # array of arrays of matched fastqs [ [r1, r2, i1], ... ]
-  File whitelist  # 10x genomics cell barcode whitelist for 10x V2
+  # Sequencing data inputs (fastq)
+  Array[File] r1 # forward read, contains cell barcodes and molecule barcodes
+  Array[File] r2 # reverse read, contains cDNA fragment generated from captured mRNA
+  Array[File]? i1 # (optional) index read, for demultiplexing of multiple samples on one flow cell.
+
+  String sample_id  # name of sample matching this file, inserted into read group header
+
+  # organism reference parameters
   File tar_star_reference  # star reference
   File annotations_gtf  # gtf containing annotations for gene tagging
   File ref_genome_fasta  # genome fasta file
-  String sample_id  # name of sample matching this file, inserted into read group header
-  String fastq_suffix = ""  # when running in green box, need to add ".gz" for picard to detect
 
-  # this scatters matched [r1, r2, i1] fastq arrays
-  scatter (fastqs in fastq_inputs) {
+  # 10x v2 parameters
+  File whitelist  # 10x genomics cell barcode whitelist for 10x V2
+
+  # environment-specific parameters
+  String fastq_suffix = ""  # when running in green box, need to add ".gz" for picard to detect
+  Array[Int] indices = range(length(r1)) # this scatters matched [r1, r2, i1] fastq arrays
+
+  scatter (index in indices) {
     call fq2bam.FastqToUBam {
       input:
-        fastq_file = fastqs[1],
+        fastq_file = r2[index],
         sample_id = sample_id,
         fastq_suffix = fastq_suffix
     }
 
-    call attach.Attach10xBarcodes {
-      input:
-        r1 = fastqs[0],
-        i1 = fastqs[2],
-        u2 = FastqToUBam.bam_output,
-        whitelist = whitelist
+    # if the index is passed, attach it to the bam file
+    if (defined(i1)) {
+      Array[File] non_optional_i1 = select_first([i1])
+      call attach.Attach10xBarcodes as attach_barcodes {
+        input:
+          r1 = r1[index],
+          i1 = non_optional_i1[index],
+          u2 = FastqToUBam.bam_output,
+          whitelist = whitelist
+      }
     }
+
+    # if the index is not passed, proceed without it.
+    if (!defined(i1)) {
+      call attach.Attach10xBarcodes as attach_barcodes_no_index {
+        input:
+          r1 = r1[index],
+          u2 = FastqToUBam.bam_output,
+          whitelist = whitelist
+      }
+    }
+
+    File barcoded_bam = select_first([attach_barcodes.bam_output, attach_barcodes_no_index.bam_output])
 
     call split.SplitBamByCellBarcode {
       input:
-        bam_input = Attach10xBarcodes.bam_output
+        bam_input = barcoded_bam
     }
 
     call AlignTagCorrectUmis.AlignTagCorrectUmis {

--- a/test/optimus/pr/test_inputs.json
+++ b/test/optimus/pr/test_inputs.json
@@ -3,17 +3,17 @@
   "TestOptimusPR.expected_matrix_hash": "69f3be6085e0c5f694b3cfa877b0eeaa",
   "TestOptimusPR.expected_matrix_summary_hash": "dd513351d4e7688c97f7bf902ba2876f",
   "TestOptimusPR.expected_picard_metrics_hash": "7b7be5c9a2236920ca09f05811dca6d5",
-  "TestOptimusPR.fastq_inputs": [
-    [
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
-    ],
-    [
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
-      "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
-    ]
+  "TestOptimusPR.r1": [
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz"
+  ],
+  "TestOptimusPR.r2": [
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz",
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_R2_001.fastq.gz"
+  ],
+  "TestOptimusPR.i1": [
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz",
+    "gs://broad-dsde-mint-dev-teststorage/10x/demo/fastqs/pbmc8k_S1_L007_I1_001.fastq.gz"
   ],
   "TestOptimusPR.whitelist": "gs://broad-dsde-mint-dev-teststorage/10x/whitelist/737K-august-2016.txt",
   "TestOptimusPR.tar_star_reference": "gs://broad-dsde-mint-dev-teststorage/demo/star.tar",

--- a/test/optimus/pr/test_optimus_PR.wdl
+++ b/test/optimus/pr/test_optimus_PR.wdl
@@ -13,7 +13,10 @@ workflow TestOptimusPR {
   String expected_picard_metrics_hash
 
   # Optimus inputs
-  Array[Array[File]] fastq_inputs  # array of arrays of matched fastqs [ [r1, r2, i1], ... ]
+  Array[File] r1
+  Array[File] r2
+  Array[File]? i1
+
   File whitelist  # 10x genomics cell barcode whitelist for 10x V2
   File tar_star_reference  # star reference
   File annotations_gtf  # gtf containing annotations for gene tagging
@@ -22,7 +25,9 @@ workflow TestOptimusPR {
 
   call target.Optimus as target {
     input:
-      fastq_inputs = fastq_inputs,
+      r1 = r1,
+      r2 = r2,
+      i1 = i1,
       whitelist = whitelist,
       tar_star_reference = tar_star_reference,
       annotations_gtf = annotations_gtf,


### PR DESCRIPTION
This PR removes the hard requirement that the user pass an index fastq file. The index is not used in any downstream steps in the pipeline and is thought by many to be superfluous. Removing the requirement increases pipeline flexibility. 