### PR TITLE
Cw add pullapprove 554

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,40 @@
+# You *must* specify "version: 2"
+version: 2
+
+requirements:
+  signed_off_by:
+    required: false
+
+always_pending:  # A pull request matching any of these conditions will always have a "pending" status for this group.
+  title_regex: '(WIP|wip)'
+  explanation: 'Work in progress...'
+
+# Group settings to apply to all groups by default, optionally being overridden later
+group_defaults:
+  reset_on_push: # Whether or not approval statuses get reset to "pending" when new commits are pushed to a PR
+    enabled: false # Set to false for efficiency
+  reset_on_reopened: # Whether or not approval statuses get reset to "pending" when a pull request is re-opened
+    enabled: true
+  author_approval: # Whether or not the author must approve the pull request.
+    required: false
+    ignored: true
+  approve_by_comment:
+    enabled: false
+  reject_value: -1 # Essentially allows rejections to cancel out approvals
+
+# Groups of reviewers and their respective settings
+groups:
+  computational-biologists:
+    required: 1 # require approval from at least one computational biologist
+    users:
+      - ambrosejcarr
+      - jishuxu
+      - mckinsel
+
+  software-engineers:
+    required: 1 # require approval from at least one software engineer
+    users:
+      - dshiga
+      - jsotobroad
+      - samanehsan
+      - rexwangcc


### PR DESCRIPTION
Previously we had soft team agreement that each Skylab PR requires approvals from both a comp-bio and a sde.  This PR adds pullapprove plugin to Skylab to make the team agreement solid. This may slow down the development efficiency a little bit at the beginning but will provide better safety and code quality in the future. 

~Also, note that `skip-review` label can be added to an emergent PR to skip the pull approval.~ 