### PR TITLE
Ajc adjust star to support mixed genomes 517

### DIFF
--- a/library/tasks/Attach10xBarcodes.wdl
+++ b/library/tasks/Attach10xBarcodes.wdl
@@ -10,7 +10,7 @@ task Attach10xBarcodes {
   # estimate disk requirements
   Float bam_size = size(u2, "G")
   Float fastq_size = size(r1, "G")  + if (defined(i1)) then size(i1, "G") else 0
-  Int estimated_required_disk = ceil(fastq_size + bam_size * 2.5)
+  Int estimated_required_disk = ceil((fastq_size + bam_size) * 2.5)
 
   command {
     Attach10xBarcodes \

--- a/library/tasks/StarAlignBamSingleEnd.wdl
+++ b/library/tasks/StarAlignBamSingleEnd.wdl
@@ -8,6 +8,7 @@ task StarAlignBamSingleEnd {
   Int input_size = ceil(size(bam_input, "G"))
   Int reference_size = ceil(size(tar_star_reference, "G"))
   Int estimated_disk_required =  ceil(input_size * 2.2 + reference_size * 2)
+  Int estimated_memory_required = reference_size + 6
 
   command {
     # prepare reference
@@ -33,7 +34,7 @@ task StarAlignBamSingleEnd {
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-star:v0.2.2-2.5.3a-40ead6e"
     cpu: 16
-    memory: "30 GB"
+    memory: "${estimated_memory_required} GB"
     disks: "local-disk ${estimated_disk_required} SSD"
   }
 

--- a/library/tasks/TagGeneExon.wdl
+++ b/library/tasks/TagGeneExon.wdl
@@ -1,10 +1,14 @@
 
 task TagGeneExon {
-  File bam_input
+  # this task requires a gtf file with no internal comments
+  # each record must have a gene_name and transcript_name in addition to a gene_id and transcript_id
+  # the annotation file must be in gtf format (terminal semicolon) not gff format.
+  # the gtf must not have any terminal white space at the end of any line
   File annotations_gtf
+  File bam_input
   Int estimated_required_disk = ceil((size(bam_input, "G") + size(annotations_gtf, "G")) * 2)
-  
-  command {
+
+ command {
     TagReadWithGeneExon \
       INPUT=${bam_input} \
       OUTPUT=bam_with_gene_exon.bam \
@@ -12,11 +16,12 @@ task TagGeneExon {
       TAG=GE \
       ANNOTATIONS_FILE=${annotations_gtf}
   }
-  
+
+  # Larger genomes (mouse-human) require a 7.5gb instance; single-organism genomes work with 3.75gb
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-dropseqtools:v0.2.2-1.12"
     cpu: 1
-    memory: "3.75 GB"
+    memory: "7.5 GB"
     disks: "local-disk ${estimated_required_disk} HDD"
   }
   


### PR DESCRIPTION
Minor adjustments to the TagGeneExon task to make it run on larger genomes (memory usage scales with genome size)