### PR TITLE
Add PR checklist

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,5 @@
+Please ensure the following when opening a PR:
+- [ ] Added or updated tests
+- [ ] Updated documentation
+- [ ] Applied style guidelines
+- [ ] Considered generalizability beyond our own use case


### PR DESCRIPTION
Adds a checklist for PRs like the one already in pipeline-tools -- example of what that looks like here: https://github.com/HumanCellAtlas/pipeline-tools/pull/35

See https://elastc.com/c/7I0aV0nQ/643-pr-checklist
