### PR TITLE
Ajc cellranger comparison test

### DIFF
--- a/test/optimus/scientific_cellranger/test_inputs.json
+++ b/test/optimus/scientific_cellranger/test_inputs.json
@@ -1,0 +1,12 @@
+{
+  "cellranger.sampleId": "synthetic",
+  "cellranger.fastqs": [
+    "gs://hca-dcp-mint-test-data/10x/synthetic/synthetic_r1.fastq.gz",
+    "gs://hca-dcp-mint-test-data/10x/synthetic/synthetic_r2.fastq.gz"
+  ],
+  "cellranger.referenceName": "GRCh38",
+  "cellranger.transcriptomeTarGz": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/refdata-cellranger-GRCh38-1.2.0.tar.gz",
+  "cellranger.secondary": true,
+  "cellranger.expectCells": "5000",
+  "cellranger.diskSpace": "250"
+}

--- a/test/trigger_cellranger_test.sh
+++ b/test/trigger_cellranger_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# note, this test must be run from the workflow root for the relative paths to work out.
+
+set -e
+
+export CROMWELL_SECRETS=~/.ssh/mint_cromwell_config.json
+
+TEST_DIR=./test/optimus/scientific_cellranger
+
+cromwell-tools run \
+  --wdl-file "${TEST_DIR}"/cellranger.wdl \
+  --inputs-json "${TEST_DIR}"/test_inputs.json

--- a/test/trigger_cellranger_test.sh
+++ b/test/trigger_cellranger_test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # note, this test must be run from the workflow root for the relative paths to work out.
+# WDL file should be the KCO cellranger, located here:
+# https://portal.firecloud.org/#methods/single-cell-portal/cell-ranger-2-0-2/3/wdl
 
 set -e
 


### PR DESCRIPTION
This small PR runs KCO cell ranger (not checked in) against the synthetic data produced by elastc [#692](https://elastc.com/c/_SzqH_AM/692-random-3--bam-generator) [#693](https://elastc.com/c/Lcl79B&&/693-random-3--fastq-generator)