### PR TITLE
Relax the approval requirement for PRs with ENG-ONLY label.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -35,6 +35,7 @@ groups:
       - mckinsel
       - mbabadi
 
+
   software-engineers:
     required: 1 # Require approval from at least one software engineer
     users:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -30,13 +30,14 @@ groups:
       - ambrosejcarr
       - jishuxu
       - mckinsel
-      - meganshand
+    conditions:
+      exclude:
+        - ENG-ONLY
       
 
   software-engineers:
     required: 1 # Require approval from at least one software engineer
     users:
       - dshiga
-      - jsotobroad
       - samanehsan
       - rexwangcc

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -26,14 +26,14 @@ group_defaults:
 groups:
   computational-biologists:
     required: 1 # Require approval from at least one computational biologist
+    conditions:
+      exclude:
+        - ENG-ONLY
     users:
       - ambrosejcarr
       - jishuxu
       - mckinsel
-    conditions:
-      exclude:
-        - ENG-ONLY
-      
+      - mbabadi
 
   software-engineers:
     required: 1 # Require approval from at least one software engineer


### PR DESCRIPTION
As a result of our team discussion, this PR relaxes the approval requirement, so that any PR with `ENG-ONLY` just requires one approval from engineer side, no need to bother Biologists anymore.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
