### PR TITLE
Add version parameter to all of the analysis pipelines except the deprecated 10x.

### DIFF
--- a/pipelines/cellranger/cellranger.wdl
+++ b/pipelines/cellranger/cellranger.wdl
@@ -2,6 +2,8 @@ workflow CellRanger {
     meta {
         description: "Analyze 3' single-cell RNA-seq data using the 10X Genomics Cellranger pipeline."
     }
+    # version of this pipeline
+    String version = "cellranger_v1.0.0"
 
     String sample_id
     Array[File] fastqs
@@ -38,6 +40,24 @@ workflow CellRanger {
         boot_disk_size_gb = boot_disk_size_gb,
         disk_space = disk_space,
         cpu = cpu
+   }
+
+   output {
+       # version of this pipeline
+       String pipeline_version = version
+
+       File qc = cellranger_count.qc
+       File sorted_bam = cellranger_count.sorted_bam
+       File sorted_bam_index = cellranger_count.sorted_bam_index
+       File barcodes = cellranger_count.barcodes
+       File genes = cellranger_count.genes
+       File matrix = cellranger_count.matrix
+       File filtered_gene_h5 = cellranger_count.filtered_gene_h5
+       File raw_gene_h5 = cellranger_count.raw_gene_h5
+       File raw_barcodes = cellranger_count.raw_barcodes
+       File raw_genes = cellranger_count.raw_genes
+       File raw_matrix = cellranger_count.raw_matrix
+       File mol_info_h5 = cellranger_count.mol_info_h5
    }
 }
 

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -13,6 +13,8 @@ workflow Optimus {
   meta {
     description: "The optimus 3' pipeline processes 10x genomics sequencing data based on the v2 chemistry. It corrects cell barcodes and UMIs, aligns reads, marks duplicates, and returns data as alignments in BAM format and as counts in sparse matrix exchange format."
   }
+  # version of this pipeline
+  String version = "optimus_v0.3.0"
 
   # Sequencing data inputs
   Array[File] r1_fastq
@@ -158,6 +160,9 @@ workflow Optimus {
   }
 
   output {
+      # version of this pipeline
+      String pipeline_version = version
+
       File bam = MergeSorted.output_bam
       File matrix = MergeCountFiles.sparse_count_matrix
       File matrix_row_index = MergeCountFiles.row_index

--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -6,6 +6,8 @@ workflow SmartSeq2SingleCell {
   meta {
     description: "Process SmartSeq2 scRNA-Seq data, include reads alignment, QC metrics collection, and gene expression quantitication"
   }
+  # version of this pipeline
+  String version = "smartseq2_v2.0.0"
 
   # load annotation
   File gtf_file
@@ -109,6 +111,9 @@ workflow SmartSeq2SingleCell {
   }
 
   output {
+    # version of this pipeline
+    String pipeline_version = version
+
     # quality control outputs
     File aligned_bam = HISAT2PairedEnd.output_bam
     File hisat2_met_file = HISAT2PairedEnd.met_file


### PR DESCRIPTION
I expect this PR should wait for @jishuxu's PR about outputs changes to be merged in so we can tag them together as `smartseq2_v2.0.0`

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
