### PR TITLE
Kmk zarr conversion scripts

### DIFF
--- a/docker/python3-scientific/Dockerfile
+++ b/docker/python3-scientific/Dockerfile
@@ -20,3 +20,10 @@ RUN pip3 install \
     tables==3.4.2 \
     numcodecs==0.5.5 \
     zarr==2.2.0
+
+RUN mkdir /tools
+
+WORKDIR /tools
+
+COPY create_zarr_ss2.py .
+

--- a/docker/python3-scientific/Dockerfile
+++ b/docker/python3-scientific/Dockerfile
@@ -8,13 +8,15 @@ RUN apt update && apt install -y \
     samtools
 
 RUN pip3 install \
-    crimson==0.3.0 \
+    crimson==0.4.0 \
     HTSeq==0.9.0 \
     matplotlib==2.1.0 \
-    numpy==1.12.0 \
+    numpy==1.15.2 \
     pandas==0.20.3 \
     pysam==0.12.0.1 \
     requests==2.18.4 \
     scipy==0.18.1 \
     sctools==0.1.6 \
-    tables==3.4.2
+    tables==3.4.2 \
+    numcodecs==0.5.5 \
+    zarr==2.2.0

--- a/library/tasks/ZarrUtils.wdl
+++ b/library/tasks/ZarrUtils.wdl
@@ -1,26 +1,34 @@
 task SmartSeq2ZarrConversion {
   # converts some of the outputs of Smart Seq 2 pipeline into a zarr file
 
-  String zarr_output    # output zarr file
-  String smartseq_output_folder   # location of the smart seq 2 output
-  String sample_id   # id of the sample
+  File rsem_gene_results # the gene count file
+  Array[File] smartseq_qc_files   # location of the smart seq 2 output
+  String sample_name   # id of the sample
 
   command {
+
+    set -e
+
+    cp /tools/create_zarr_ss2.py ./
+
+    python3 ./create_zarr_ss2.py  -h
+
     python3 create_zarr_ss2.py \
-      --analysis_output_path ${smartseq_output_folder} \
-      --output_path_for_zarr  ${zarr_output} \
-      --sample_id ${sample_id} \
-      --format DirectoryStore
+       --qc_analysis_output_files_string ${sep=',' smartseq_qc_files} \
+       --rsem_genes_results  ${rsem_gene_results} \
+       --output_path_for_zarr  "${sample_name}.zip" \
+       --sample_id ${sample_name} \
+       --format ZipStore
   }
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.6"
+    docker: "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.6_zarr_test"
     cpu: 4  # note that only 1 thread is supported by pseudobam
     memory: "16 GB"
     disks: "local-disk 100 HDD"
   }
 
   output {
-    File zarr_output = zarr_output
+    Array[File]  zarr_output_files = glob("*.zip")
   }
 }

--- a/library/tasks/ZarrUtils.wdl
+++ b/library/tasks/ZarrUtils.wdl
@@ -1,0 +1,26 @@
+task SmartSeq2ZarrConversion {
+  # converts some of the outputs of Smart Seq 2 pipeline into a zarr file
+
+  String zarr_output    # output zarr file
+  String smartseq_output_folder   # location of the smart seq 2 output
+  String sample_id   # id of the sample
+
+  command {
+    python3 create_zarr_ss2.py \
+      --analysis_output_path ${smartseq_output_folder} \
+      --output_path_for_zarr  ${zarr_output} \
+      --sample_id ${sample_id} \
+      --format DirectoryStore
+  }
+
+  runtime {
+    docker: "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.6"
+    cpu: 4  # note that only 1 thread is supported by pseudobam
+    memory: "16 GB"
+    disks: "local-disk 100 HDD"
+  }
+
+  output {
+    File zarr_output = zarr_output
+  }
+}

--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -119,9 +119,9 @@ workflow SmartSeq2SingleCell {
 
   call ZarrUtils.SmartSeq2ZarrConversion{
     input:
-      zarr_output="${sample_name}.zarr",
-      smartseq_output_folder=<analysis bundle path>,
-      sample_id=sample_name
+      rsem_gene_results = RSEMExpression.rsem_gene,
+      smartseq_qc_files = GroupQCOutputs.group_files,
+      sample_name=sample_name
   }
 
   output {
@@ -142,6 +142,6 @@ workflow SmartSeq2SingleCell {
     File rsem_isoform_results = RSEMExpression.rsem_isoform
 
     # zarr
-    File zarr_output = SmartSeq2ZarrConversion.zarr_output
+    Array [File] zarr_output_files = SmartSeq2ZarrConversion.zarr_output_files
   }
 }

--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -2,6 +2,7 @@ import "HISAT2.wdl" as HISAT2
 import "Picard.wdl" as Picard
 import "RSEM.wdl" as RSEM
 import "GroupMetricsOutputs.wdl" as GroupQCs
+import "ZarrUtils.wdl" as ZarrUtils
 
 workflow SmartSeq2SingleCell {
   meta {
@@ -116,6 +117,13 @@ workflow SmartSeq2SingleCell {
       output_name = output_name
   }
 
+  call ZarrUtils.SmartSeq2ZarrConversion{
+    input:
+      zarr_output="${sample_name}.zarr",
+      smartseq_output_folder=<analysis bundle path>,
+      sample_id=sample_name
+  }
+
   output {
     # version of this pipeline
     String pipeline_version = version
@@ -132,5 +140,8 @@ workflow SmartSeq2SingleCell {
     File aligned_transcriptome_bam = HISAT2Transcriptome.output_bam
     File rsem_gene_results = RSEMExpression.rsem_gene
     File rsem_isoform_results = RSEMExpression.rsem_isoform
+
+    # zarr
+    File zarr_output = SmartSeq2ZarrConversion.zarr_output
   }
 }

--- a/test/create_zarr_ss2.py
+++ b/test/create_zarr_ss2.py
@@ -1,0 +1,194 @@
+import argparse
+import csv
+import glob
+import json
+import os, sys
+import re, logging
+
+import crimson.picard
+import numcodecs.blosc
+import numpy
+import zarr
+
+""" key,  dataset name,   suffix of file,  metadata description 
+    this is a list of groups to add to the zarr file, which can be 
+    further extended
+"""
+_FILES = {
+  "QCs" : [ "QCs", "*_QCs.csv",  "QC data" ], 
+  "genes_results"  : [ "TPM", "*_rsem.genes.results", "count for the genes and also isoforms" ],
+}
+
+COMPRESSOR = numcodecs.blosc.Blosc(cname='lz4', clevel=5, shuffle=1, blocksize=0)
+
+def init_zarr(sample_id, path, fileformat):
+    """  Creates an empty zarr file  in the path
+        Args:
+            path:  path to the zarr 
+        Returns:
+            
+        Raises:
+    """
+    if fileformat=="DirectoryStore":
+        store = zarr.DirectoryStore(path)
+
+    if fileformat=="ZipStore":
+       store= zarr.ZipStore(path, mode='w')
+
+    # create the root group
+    root = zarr.group(store, overwrite=True)
+
+    # add some readme for the user
+    root.attrs['README'] = "The schema adopted in this zarr store may undergo changes in future"
+    root.attrs['sample_id'] = sample_id
+
+    # now iterate through list of expected groups and create them
+    for data in _FILES:
+      datagroup = root.create_group(data, overwrite=True)
+      datagroup.attrs['description'] = _FILES[data][2]
+
+    return root
+
+
+def read_and_convert_QC(root, input_files_string):
+    """Converts the QC of Smart Seq2 gene file pipeline outputs to zarr file
+        Args:
+            root: root object for the zarr
+            analysis_output_path: path where the SS2 pipeline are found 
+        Returns:
+            True if success else False
+        Raises:
+
+    """
+    
+    # split the files string by , 
+    # crate an array of the file names containing the suffix _QCs.csv 
+    relevant_qc_files =  [  x.strip() for x in input_files_string.split(',')  if re.search(r'_QCs.csv$', x) ]
+
+    # we expect only one, write an warning 
+    if len(relevant_qc_files) !=1:
+       logging.warning(sys.stderr.write("WARNING: Multiple files ending with _QCs.csv. Expected only one"))
+
+
+    # read the QC values
+    QC_values = []
+    with open(relevant_qc_files[0], 'r') as f:
+       reader = csv.reader(f)
+       for row in reader:
+          QC_values.append(row)
+
+    datagroup = root['QCs']
+
+    # Metrics
+    """ The first value is the row name so we remove it"""
+    
+    metrics_array=datagroup.create_dataset(
+        "QCs",
+        shape=(len(QC_values[0][1:]), ),
+        dtype='<U40',
+        chunks=(len(QC_values[0][1:]), ),
+        data = QC_values[0][1:]
+     )
+
+    # Class
+    metrics_array=datagroup.create_dataset(
+        "Class",
+        shape=(len(QC_values[0][1:]), ),
+        dtype='<U40',
+        chunks=(len(QC_values[0][1:]), ),
+        data = QC_values[0][1:] 
+     )
+
+   # Values, which are the values of the metrics
+    metrics_array=datagroup.create_dataset(
+        "Values",
+        shape=(len(QC_values[2][1:]), ),
+        dtype='<U40',
+        chunks=(len(QC_values[2][1:]), ),
+        data = QC_values[2][1:]
+     )
+      
+
+def read_and_convert_expression(root, input_path):
+    """Converts the Smart Seq2 gene file pipeline outputs to zarr file
+        Args:
+            root: root object for the zarr
+            analysis_output_path: path where the SS2 pipeline are found 
+        Returns:
+            True if success else False
+        Raises:
+            FileNotFoundError
+    """
+    #expression_path = glob.glob(os.path.join(input_path, _FILES['genes_results'][1]))[0]
+    reader = csv.DictReader(open(input_path), delimiter="\t")
+
+    expression_values = {}
+    for row in reader:
+        expression_values[row["gene_id"]] = float(row["TPM"])
+
+    datagroup = root['genes_results']
+
+    # Gene IDs
+    gene_id_array = datagroup.create_dataset(
+        "gene_id",
+        shape=(len(expression_values),),
+        dtype="<U40",
+        chunks=(len(expression_values), ), 
+        data=list(expression_values.keys())
+    )
+
+    # TPM
+    expression_array=datagroup.create_dataset(
+        "TPM",
+        shape=(len(expression_values), ),
+        dtype=numpy.float32,
+        chunks=(len(expression_values), ),
+        data= list(expression_values.values())
+     )
+      
+
+
+def create_zarr_files(sample_id,qc_analysis_output_files_string, rsem_genes_results_file,  output_zarr_path, fileformat):
+    """ This function creates the zarr file in output_zarr_path in format fileformat,
+        with sample_id from the input folder analysis_output_path  """
+
+    #initiate the zarr file 
+    root = init_zarr(sample_id, output_zarr_path, fileformat)
+
+    # add the the gene/TMP counts
+    read_and_convert_expression(root, rsem_genes_results_file)
+
+    # add the the QC metrics
+    read_and_convert_QC(root, qc_analysis_output_files_string)
+
+def main():
+    description = """This script converts the some of the SmartSeq2 pipeline outputs in to
+                   zarr format (https://zarr.readthedocs.io/en/stable/) relevant output. 
+                   This script can be used as a module or run as a command line script."""
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--qc_analysis_output_files_string', dest="qc_analysis_output_files_string", 
+                        help='a string separated by commas with a list of files from the GroupQCOutputs step of SS2 pipeline'
+                       )
+
+    parser.add_argument('--rsem_genes_results', dest="rsem_genes_results", 
+                        help='path to the folder containing the files to be added to the zarr'
+                       )
+    parser.add_argument('--output_path_for_zarr', dest="output_zarr_path",
+                        help='path where the zarr file is to be created'
+                       )
+    parser.add_argument('--sample_id', dest="sample_id", default="Unknown sample",
+                        help='the sample name in the bundle'
+                       )
+
+    parser.add_argument('--format', dest="format", default="DirectoryStore",
+                        help='format of the zarr file choices: [DirectoryStore, ZipStore] default: DirectoryStore'
+                       )
+    args = parser.parse_args()
+
+    create_zarr_files(args.sample_id, args.qc_analysis_output_files_string, args.rsem_genes_results, args.output_zarr_path, args.format)
+    #add_cell_metadata(root, args.analysis_output_path)
+    #add_gene_metadata(root, args.analysis_output_path)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Zarr file conversion changes 

(a) test/create_zarr_ss2.py is the python script that changes the SS2 output to zarr format. Note that this script is planned to be added to the sctools repository, but for now, while testing, we are adding it  the docker image "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.6_zarr_test".  Eventually, this script will be changed to change the format of the zarr file contents, but for now it tests its ability to create zarr file.

(b)  library/tasks/ZarrUtils.wdl defines the task for the conversion to the zarr format; 
Note that when we are calling the script is it providing the ZipStore option, to create a single file format of the zarr file .  <sample_name>.zip . Note the line 
 output {
    Array[File]  zarr_output_files = glob("*.zip")
  }
in the script is used to capture the output. Although the glob is not required but for DirectoryStore format we might need to it as this format is essentially a hierarchy of folders and files. 

When I tried to use  DirectoryStore option for the zarr library,  the final output in "mint-cromwell job manager" does not contail  final zarr output  <sample_name>.zarr. Note that is is a directory structure (not a single file) but the cromwell gives me error on it" as follows (sample_name is SRR1294925) 
"ln: â€˜SRR1294925.zarrâ€™: hard link not allowed for directory" but the cromwell task runs successfully. This seems to an forlder copying issue from the docker mounted drive to  
"gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/SmartSeq2SingleCell/"

(c) pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl is modified to add the zarr file creation task  to the end of the SS2 workflow. 

(d) docker/python3-scientific/Dockerfile is modified to add the python conversion script to create the docker images for the python3-scientific scripts, which is required to run the conversion script"
Note that in this Dockerfile, the python script (in a) is copied to the docker image  for now,  and it is used to  create the docker image "quay.io/humancellatlas/secondary-analysis-python3-scientific:0.1.6_zarr_test" for the tests


