### PR TITLE
Add WDL linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,8 @@ jobs:
                 command: |
                     python3 -m venv venv
                     . venv/bin/activate
-                    pip install requests
+                    pip install miniwdl requests
+                    miniwdl check pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl --path library/tasks
+                    miniwdl check pipelines/optimus/Optimus.wdl --path library/tasks
+                    miniwdl check pipelines/cellranger/cellranger.wdl --path library/tasks
                     python test/run_portability_test.py --test-directories test/smartseq2_single_sample/pr/ test/optimus/pr

--- a/library/tasks/GroupMetricsOutputs.wdl
+++ b/library/tasks/GroupMetricsOutputs.wdl
@@ -7,9 +7,9 @@ task GroupQCOutputs {
   String output_name
   # Runtime
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.0"
-  String mem = 2
-  String cpu = 1
-  String disk_space = 20 
+  Int mem = 2
+  Int cpu = 1
+  Int disk_space = 20
   Int preemptible = 5
   Int max_retries = 0
   

--- a/test/README.md
+++ b/test/README.md
@@ -42,3 +42,9 @@ of the jenkins instance.
 Thus, the `WDL_FILE`, and `DEPENDENCIES_JSON` (and any files inside the dependencies with local paths) are interpreted from within the docker as referencing the relevant files on the current branch. 
 
 The scientific test does not yet implement the comparison to Cell Ranger, but it does contain a testing script `trigger_scientific_test.sh` which can be run to trigger Optimus to run on the synthetic data. 
+
+**Static Analysis/Linting**
+
+As part of the PR tests, the [miniwdl](https://github.com/chanzuckerberg/miniwdl) linting tool is run all WDLs in the skylab repo. This identifies certain WDL issues like undesirable type conversions or WDL style problems. Problems found by `miniwdl` do not cause the PR test to fail but generally should be looked into by the developer.
+
+The default linting rules are implemented [here](https://github.com/chanzuckerberg/miniwdl/blob/master/WDL/Lint.py) and will likely grow over time.


### PR DESCRIPTION
This turns on `miniwdl check` in the circleci tests. The goal is to apply linting rules to our WDLs that identify some basic syntax or style issues. Presently, the list of rules is pretty limited, but it's something we can expand over time.