### PR TITLE
Fix SS2 Jenkins test permissions

### DIFF
--- a/test/config/render-ctmpls.sh
+++ b/test/config/render-ctmpls.sh
@@ -15,4 +15,5 @@ docker run --rm -v ${working_dir}:/working \
     -e VAULT_TOKEN=${vault_token} \
     -e INPUT_PATH=/working/test/config \
     -e OUT_PATH=/working/test \
+    --privileged \
     "${docker_image}" render-templates.sh ${env}

--- a/test/trigger_test.sh
+++ b/test/trigger_test.sh
@@ -25,6 +25,7 @@ echo "Running test"
 docker run --rm \
   -v ${WD}:/working \
   -w /working \
+  --privileged \
   humancellatlas/cromwell-tools:1.0.1 \
   /working/test/test_cromwell_workflow.sh \
     "${CROMWELL_USER}" \


### PR DESCRIPTION
### Purpose

- Fixes the failing SS2 jenkins tests in this repo. Issue: https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/463

### Changes
- Added `--privileged` flag so that the user inside of the docker containers run by the test have the right file permissions 

### Review Instructions
- Jenkins SS2 test is passing

### PR Checklist

- [x] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] Let Jodi (**jodihir**) know when there is user-facing documentation updates needed!
- [ ] This PR applied the Mint style guide for WDL.
- [ ] This PR has no WDL linting errors reported by [miniwdl](https://github.com/chanzuckerberg/miniwdl)
- [ ] This PR considered generalizability beyond our own use case.

### Follow-up Discussions

- No follow-up discussions.
