### PR TITLE
Standardize sctools version

### DIFF
--- a/library/tasks/Attach10xBarcodes.wdl
+++ b/library/tasks/Attach10xBarcodes.wdl
@@ -5,7 +5,7 @@ task Attach10xBarcodes {
   File whitelist
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 7500
   Int cpu = 2
   # estimate that bam is approximately the size of all inputs plus 50%

--- a/library/tasks/CreateCountMatrix.wdl
+++ b/library/tasks/CreateCountMatrix.wdl
@@ -57,7 +57,7 @@ task CreateSparseCountMatrix {
   File gtf_file
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.1"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = ceil((size(bam_input, "G") + size(gtf_file, "G")) * 4.0) + 1
@@ -111,7 +111,7 @@ task MergeCountFiles {
   Array[File] col_indices
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.10"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = 20  # todo find out how to make this adaptive with Array[file] input

--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -2,7 +2,7 @@ task CalculateGeneMetrics {
   File bam_input
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 10000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "G") * 4)
@@ -44,7 +44,7 @@ task CalculateCellMetrics {
   File bam_input
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = ceil(size(bam_input, "G") * 2)
@@ -87,7 +87,7 @@ task MergeGeneMetrics {
   Array[File] metric_files
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = 20
@@ -129,7 +129,7 @@ task MergeCellMetrics {
   Array[File] metric_files
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = 20

--- a/library/tasks/SplitBamByCellBarcode.wdl
+++ b/library/tasks/SplitBamByCellBarcode.wdl
@@ -3,7 +3,7 @@ task SplitBamByCellBarcode {
   Float size_in_mb = 1024.0
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.1.9"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 3500
   Int cpu = 1
   # estimate that bam is approximately equal in size to the input bam, add 20% buffer

--- a/library/tasks/TagSortBam.wdl
+++ b/library/tasks/TagSortBam.wdl
@@ -2,7 +2,7 @@ task CellSortBam {
   File bam_input
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.2.0"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 40000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "G") * 8)
@@ -44,7 +44,7 @@ task GeneSortBam {
   File bam_input
 
   # runtime values
-  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:0.2.0"
+  String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
   Int machine_mem_mb = 40000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "G") * 4)

--- a/test/optimus/pr/test_inputs.json
+++ b/test/optimus/pr/test_inputs.json
@@ -1,7 +1,7 @@
 {
   "TestOptimusPR.expected_bam_hash": "85975323e23b566297c5099e0a0365ba",
   "TestOptimusPR.expected_matrix_hash": "aec7a79dc7b85a5d621509a3f4fa2192",
-  "TestOptimusPR.expected_cell_metric_hash": "aa9377b2161ef089a3422c140b0c07ca",
+  "TestOptimusPR.expected_cell_metric_hash": "1efd1cd4fdd7d0dde9be0c1f93aa6351",
   "TestOptimusPR.expected_gene_metric_hash": "bdb60844ab8bf35d2f632af0feb60eeb",
   "TestOptimusPR.r1_fastq": [
     "gs://hca-dcp-mint-test-data/10x/demo/fastqs/pbmc8k_S1_L007_R1_001.fastq.gz",


### PR DESCRIPTION
### Purpose
The Optimus pipeline was using several different and outdated versions of sctools

Fixes https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/455

---
### Changes
Changes the version of sctools to `v0.3.2` wherever it is used in Optimus

---
### Review Instructions
- No instructions.

---
### PR Checklist
- [x] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] Let Jodi (**jodihir**) know when there is user-facing documentation updates needed!
- [x] This PR applied the Mint style guide for WDL.
- [x] This PR has no WDL linting errors reported by [miniwdl](https://github.com/chanzuckerberg/miniwdl)
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
