### PR TITLE
Fix sort order before count matrix generation [WIP]

### DIFF
--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -148,9 +148,15 @@ workflow Optimus {
         bam_input = CellSortBam.bam_output
     }
 
+    call Picard.SortBamAndIndex as PreCountSort {
+      input:
+        bam_input = MarkDups.bam_output
+	sort_order = "queryname"
+    }
+
     call Count.CreateSparseCountMatrix {
       input:
-        bam_input = CellSortBam.bam_output,
+        bam_input = PreCountSort.bam_output,
         gtf_file = annotations_gtf
     }
   }

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -148,7 +148,7 @@ workflow Optimus {
         bam_input = CellSortBam.bam_output
     }
 
-    call Picard.SortBamAndIndex as PreCountSort {
+    call Picard.SortBam as PreCountSort {
       input:
         bam_input = MarkDups.bam_output,
 	sort_order = "queryname"

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -150,7 +150,7 @@ workflow Optimus {
 
     call Picard.SortBamAndIndex as PreCountSort {
       input:
-        bam_input = MarkDups.bam_output
+        bam_input = MarkDups.bam_output,
 	sort_order = "queryname"
     }
 


### PR DESCRIPTION
This is a bug fix for ticket #553 whereby the sort order of the reads for counting was not what was required by sctools counting

It must be merged into nb-add-umitools because it requires a step from picard added there

