### PR TITLE
Phs add preemptible where sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ For now, use `git clone git@github.com:HumanCellAtlas/skylab.git` and run the pi
 1. WDL and Cromwell [Documentation](https://software.broadinstitute.org/wdl/)
 2. Running WDLs in [Cromwell](https://software.broadinstitute.org/wdl/documentation/execution.php)
 
+### preemptible
+
+Tasks on Cromwell may be run on what are known as "preemptible" machines to reduce costs by a significant amount. The catch with preemptible machines is that they may be "preempted" at any given moment--as in, google may shut down the task to re-use the resources.
+
+Many tasks are set to automatically be `preemptible = 3`, aka they will be run on preemptible instances for up to 3 instances of preemption, after which it will be run on a non-preemptible machine. The Optimus pipeline in particular also has a `preemptible` input that overrides the default preemptible parameter on all tasks run through optimus. This option may be set to 0 to run the entire workflow without using preemptible machines.
+
 ### maxRetries
 
 Some tasks have a maxRetries runtime attribute specified, with the default value set to zero. You probably shouldn't override the default and even if you do, you should do so with caution.

--- a/library/tasks/Attach10xBarcodes.wdl
+++ b/library/tasks/Attach10xBarcodes.wdl
@@ -10,7 +10,7 @@ task Attach10xBarcodes {
   Int cpu = 2
   # estimate that bam is approximately the size of all inputs plus 50%
   Int disk = ceil((size(r2_unmapped_bam, "G") + size(r1_fastq, "G") + if (defined(i1_fastq)) then size(i1_fastq, "G") else 0) * 2.5)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "attaches barcodes found in r1 (forward) and i1 (index) fastq files to corresponding reads in the r2 (reverse) bam file"

--- a/library/tasks/CorrectUmiMarkDuplicates.wdl
+++ b/library/tasks/CorrectUmiMarkDuplicates.wdl
@@ -9,7 +9,7 @@ task SortAndCorrectUmiMarkDuplicates {
   Int cpu = 1
   # mark duplicates swaps a large amount of data to disk, has high disk requirements.
   Int disk = ceil(size(bam_input, "G") * 6) + 50
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Iterates over reads in a bam file, marking duplicate reads by setting bit 0x400 in the SAM flag and correcting any barcodes with errors by storing the original barcode in tag UR."

--- a/library/tasks/CreateCountMatrix.wdl
+++ b/library/tasks/CreateCountMatrix.wdl
@@ -7,7 +7,7 @@ task DropSeqToolsDigitalExpression {
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = ceil((size(bam_input, "G") + size(whitelist, "G")) * 4.0) + 1
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Constructs a tab-delimited gzipped count matrix from a bam file containing reads marked with cell barcodes (CB), molecule barcodes (UB) and gene ids (GE)"
@@ -61,7 +61,7 @@ task CreateSparseCountMatrix {
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = ceil((size(bam_input, "G") + size(gtf_file, "G")) * 4.0) + 1
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Constructs a compressed sparse row matrix from a bam file containing reads marked with cell barcodes (CB), molecule barcodes (UB) and gene ids (GE)"
@@ -115,7 +115,7 @@ task MergeCountFiles {
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = 20  # todo find out how to make this adaptive with Array[file] input
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Constructs a compressed sparse row matrix by concatenating multiple input matrices"

--- a/library/tasks/FastqToUBam.wdl
+++ b/library/tasks/FastqToUBam.wdl
@@ -11,7 +11,7 @@ task FastqToUBam {
   Int cpu = 1
   # estimate that bam is approximately equal in size to fastq, add 20% buffer
   Int disk = ceil(size(fastq_file, "G") * 2.2)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Converts a fastq file into an unaligned bam file."

--- a/library/tasks/MarkDuplicates.wdl
+++ b/library/tasks/MarkDuplicates.wdl
@@ -12,7 +12,7 @@ task MarkDuplicatesUmiTools {
     Int machine_mem_mb = 10000
     Int cpu = 1
     Int disk = ceil(size(bam_input, "G") * 6) + 50
-    Int preemptible = 0
+    Int preemptible = 3
 
     meta {
         description: "Marks duplicates using umitools group specifically for single-cell experiments"

--- a/library/tasks/MergeSortBam.wdl
+++ b/library/tasks/MergeSortBam.wdl
@@ -12,7 +12,7 @@ task MergeSortBamFiles {
   Int cpu = 1
   # default to 500GB of space
   Int disk = 500
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Merge multiple bam files in the specified sort order"

--- a/library/tasks/Picard.wdl
+++ b/library/tasks/Picard.wdl
@@ -48,7 +48,7 @@ task SortBamAndIndex {
     Int command_mem_mb = machine_mem_mb - machine_overhead_mb
     Int cpu = 1
     Int disk = ceil(size(bam_input, "G") * 6) + 50
-    Int preemptible = 0
+    Int preemptible = 3
 
     meta {
         description: "Sorts bam by genomic position"

--- a/library/tasks/Picard.wdl
+++ b/library/tasks/Picard.wdl
@@ -9,7 +9,7 @@ task SortBam {
     Int command_mem_mb = machine_mem_mb - machine_overhead_mb
     Int cpu = 1
     Int disk = ceil(size(bam_input, "G") * 6) + 50
-    Int preemptible = 0
+    Int preemptible = 3
 
     meta {
         description: "Sorts bam"

--- a/library/tasks/RunEmptyDrops.wdl
+++ b/library/tasks/RunEmptyDrops.wdl
@@ -13,7 +13,7 @@ task RunEmptyDrops {
     Int machine_mem_mb = 4000
     Int cpu = 1
     Int disk = 20
-    Int preemptible = 0
+    Int preemptible = 3
 
     meta {
         description: "Runs empty drops on the count matrix and calls cells on the  basis of the provided cutoff value"

--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -6,7 +6,7 @@ task CalculateGeneMetrics {
   Int machine_mem_mb = 10000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "G") * 4)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Calculate gene metrics from the reads in bam_input."
@@ -48,7 +48,7 @@ task CalculateCellMetrics {
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = ceil(size(bam_input, "G") * 2)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Calculate cell metrics from the reads in bam_input."
@@ -91,7 +91,7 @@ task MergeGeneMetrics {
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = 20
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Merge an array of gene metric files with the same metric categories and potentially overlapping sets of gene features"
@@ -133,7 +133,7 @@ task MergeCellMetrics {
   Int machine_mem_mb = 3500
   Int cpu = 1
   Int disk = 20
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Concatenate multiple cell metrics files into a single matrix"

--- a/library/tasks/SplitBamByCellBarcode.wdl
+++ b/library/tasks/SplitBamByCellBarcode.wdl
@@ -8,7 +8,7 @@ task SplitBamByCellBarcode {
   Int cpu = 1
   # estimate that bam is approximately equal in size to the input bam, add 20% buffer
   Int disk = ceil(size(bam_input, "G") * 2.2)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Splits a bam file into chunks of size_in_mb, guaranteeing that all information for each cell is fully contained in only one of the chunks"

--- a/library/tasks/StarAlignBamSingleEnd.wdl
+++ b/library/tasks/StarAlignBamSingleEnd.wdl
@@ -8,7 +8,7 @@ task StarAlignBamSingleEnd {
   Int cpu = 16
   # multiply input size by 2.2 to account for output bam file + 20% overhead, add size of reference.
   Int disk = ceil((size(tar_star_reference, "G") * 2) + (size(bam_input, "G") * 2.2))
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Aligns reads in bam_input to the reference genome in tar_star_reference"

--- a/library/tasks/TagGeneExon.wdl
+++ b/library/tasks/TagGeneExon.wdl
@@ -7,7 +7,7 @@ task TagGeneExon {
   Int machine_mem_mb = 7500
   Int cpu = 1
   Int disk = ceil((size(bam_input, "G") + size(annotations_gtf, "G")) * 2)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Tags any read in bam_input that overlaps an intron or exon interval with the gene that those interals correspond to."

--- a/library/tasks/TagSortBam.wdl
+++ b/library/tasks/TagSortBam.wdl
@@ -6,7 +6,7 @@ task CellSortBam {
   Int machine_mem_mb = 40000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "G") * 8)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Sort bam_input by cell, then molecule, then gene."
@@ -48,7 +48,7 @@ task GeneSortBam {
   Int machine_mem_mb = 40000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "G") * 4)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Sort bam_input by gene, then cell, then molecule."

--- a/library/tasks/ZarrUtils.wdl
+++ b/library/tasks/ZarrUtils.wdl
@@ -9,6 +9,8 @@ task SmartSeq2ZarrConversion {
   # name of the sample
   String sample_name
 
+  Int preemptible = 3
+
   meta {
     description: "This  task will converts some of the outputs of Smart Seq 2 pipeline into a zarr file"
   }
@@ -46,6 +48,7 @@ task SmartSeq2ZarrConversion {
     cpu: 4  # note that only 1 thread is supported by pseudobam
     memory: "16 GB"
     disks: "local-disk 100 HDD"
+    preemptible: preemptible
   }
 
   output {
@@ -71,6 +74,8 @@ task OptimusZarrConversion {
   File gene_id
   # emptydrops output metadata
   File empty_drops_result
+
+  Int preemptible = 3
 
   meta {
     description: "This task will converts some of the outputs of Optimus pipeline into a zarr file"
@@ -112,6 +117,7 @@ task OptimusZarrConversion {
     cpu: 4  # note that only 1 thread is supported by pseudobam
     memory: "16 GB"
     disks: "local-disk 100 HDD"
+    preemptible: preemptible
   }
 
   output {

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -41,6 +41,8 @@ workflow Optimus {
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
 
+  Int preemptible = 3
+
   parameter_meta {
     r1_fastq: "forward read, contains cell barcodes and molecule barcodes"
     r2_fastq: "reverse read, contains cDNA fragment generated from captured mRNA"
@@ -52,6 +54,7 @@ workflow Optimus {
     whitelist: "10x genomics cell barcode whitelist for 10x V2"
     fastq_suffix: "when running in green box, need to add '.gz' for picard to detect the compression"
     output_zarr: "whether to run the taks that converts the outputs to Zarr format, by default it's true"
+    preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
   }
 
   scatter (index in indices) {
@@ -59,7 +62,8 @@ workflow Optimus {
       input:
         fastq_file = r2_fastq[index],
         sample_id = sample_id,
-        fastq_suffix = fastq_suffix
+        fastq_suffix = fastq_suffix,
+        preemptible = preemptible
     }
 
     # if the index is passed, attach it to the bam file
@@ -70,7 +74,8 @@ workflow Optimus {
           r1_fastq = r1_fastq[index],
           i1_fastq = non_optional_i1_fastq[index],
           r2_unmapped_bam = FastqToUBam.bam_output,
-          whitelist = whitelist
+          whitelist = whitelist,
+          preemptible = preemptible
       }
     }
 
@@ -80,7 +85,8 @@ workflow Optimus {
         input:
           r1_fastq = r1_fastq[index],
           r2_unmapped_bam = FastqToUBam.bam_output,
-          whitelist = whitelist
+          whitelist = whitelist,
+          preemptible = preemptible
       }
     }
 
@@ -90,93 +96,109 @@ workflow Optimus {
   call Merge.MergeSortBamFiles as MergeUnsorted {
     input:
       bam_inputs = barcoded_bam,
-      sort_order = "unsorted"
+      sort_order = "unsorted",
+      preemptible = preemptible
   }
 
   call Split.SplitBamByCellBarcode {
     input:
-      bam_input = MergeUnsorted.output_bam
+      bam_input = MergeUnsorted.output_bam,
+      preemptible = preemptible
   }
 
   scatter (bam in SplitBamByCellBarcode.bam_output_array) {
     call StarAlignBam.StarAlignBamSingleEnd as StarAlign {
       input:
         bam_input = bam,
-        tar_star_reference = tar_star_reference
+        tar_star_reference = tar_star_reference,
+        preemptible = preemptible
     }
 
     call TagGeneExon.TagGeneExon as TagGenes {
       input:
         bam_input = StarAlign.bam_output,
-        annotations_gtf = annotations_gtf
+        annotations_gtf = annotations_gtf,
+        preemptible = preemptible
     }
 
     call CorrectUmiMarkDuplicates.SortAndCorrectUmiMarkDuplicates {
       input:
-        bam_input = TagGenes.bam_output
+        bam_input = TagGenes.bam_output,
+        preemptible = preemptible
     }
 
     call TagSortBam.GeneSortBam {
       input:
-        bam_input = SortAndCorrectUmiMarkDuplicates.bam_output
+        bam_input = SortAndCorrectUmiMarkDuplicates.bam_output,
+        preemptible = preemptible
     }
 
     call TagSortBam.CellSortBam {
       input:
-        bam_input = SortAndCorrectUmiMarkDuplicates.bam_output
+        bam_input = SortAndCorrectUmiMarkDuplicates.bam_output,
+        preemptible = preemptible
     }
 
     call Metrics.CalculateGeneMetrics {
       input:
-        bam_input = GeneSortBam.bam_output
+        bam_input = GeneSortBam.bam_output,
+        preemptible = preemptible
     }
 
     call Metrics.CalculateCellMetrics {
       input:
-        bam_input = CellSortBam.bam_output
+        bam_input = CellSortBam.bam_output,
+        preemptible = preemptible
     }
 
     call Picard.SortBam as PreCountSort {
       input:
         bam_input = SortAndCorrectUmiMarkDuplicates.bam_output,
-        sort_order = "queryname"
+        sort_order = "queryname",
+        preemptible = preemptible
     }
 
     call Count.CreateSparseCountMatrix {
       input:
         bam_input = PreCountSort.bam_output,
-        gtf_file = annotations_gtf
+        gtf_file = annotations_gtf,
+        preemptible = preemptible
     }
   }
 
   call Merge.MergeSortBamFiles as MergeSorted {
     input:
       bam_inputs = SortAndCorrectUmiMarkDuplicates.bam_output,
-      sort_order = "coordinate"
+      sort_order = "coordinate",
+      preemptible = preemptible
   }
 
   call Metrics.MergeGeneMetrics {
     input:
-      metric_files = CalculateGeneMetrics.gene_metrics
+      metric_files = CalculateGeneMetrics.gene_metrics,
+      preemptible = preemptible
   }
 
   call Metrics.MergeCellMetrics {
     input:
-      metric_files = CalculateCellMetrics.cell_metrics
+      metric_files = CalculateCellMetrics.cell_metrics,
+      preemptible = preemptible
   }
 
   call Count.MergeCountFiles {
     input:
       sparse_count_matrices = CreateSparseCountMatrix.sparse_count_matrix,
       row_indices = CreateSparseCountMatrix.row_index,
-      col_indices = CreateSparseCountMatrix.col_index
+      col_indices = CreateSparseCountMatrix.col_index,
+      preemptible = preemptible
   }
 
   call RunEmptyDrops.RunEmptyDrops {
     input:
-       sparse_count_matrix = MergeCountFiles.sparse_count_matrix,
-       row_index = MergeCountFiles.row_index,
-       col_index = MergeCountFiles.col_index
+      sparse_count_matrix = MergeCountFiles.sparse_count_matrix,
+      row_index = MergeCountFiles.row_index,
+      col_index = MergeCountFiles.col_index,
+      preemptible = preemptible
   }
 
   if (output_zarr) {
@@ -188,7 +210,8 @@ workflow Optimus {
         sparse_count_matrix = MergeCountFiles.sparse_count_matrix,
         cell_id = MergeCountFiles.row_index,
         gene_id = MergeCountFiles.col_index,
-        empty_drops_result = RunEmptyDrops.empty_drops_result
+        empty_drops_result = RunEmptyDrops.empty_drops_result,
+        preemptible = preemptible
     }
 }
 

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -130,12 +130,14 @@ workflow Optimus {
     call MarkDuplicates.MarkDuplicatesUmiTools as MarkDuplicates {
       input:
         bam_input = PreUMISort.bam_output,
-        bam_index = PreUMISort.bam_index
+        bam_index = PreUMISort.bam_index,
+        preemptible = preemptible
     }
 
     call Picard.SortBamAndIndex as PostUMISort {
       input:
-        bam_input = MarkDuplicates.bam_output
+        bam_input = MarkDuplicates.bam_output,
+        preemptible = preemptible
     }
 
     call TagSortBam.GeneSortBam {


### PR DESCRIPTION
### Purpose
This PR contains changes that sets Optimus to default run all tasks as preemptible, with an option to run all tasks as non-preemptible.

---
### Changes

- All tasks called directly by `Optimus.wdl` have had their default preemptible value set to 3. (This is technically extraneous, since `Optimus.wdl` now always passes a `preemptible` value to every task called.)
- The `preemptible` variable has been added to `ZarrUtils.wdl > SmartSeq2ZarrConversion` & `ZarrUtils.wdl > OptimusZarrConversion`. The `preemptible` variable has previously been described in the `parameter_meta` section of both of these tasks but was not actually implemented.
- `Optimus.wdl` now also takes an optional parameter `preemptible` that sets the preemptibility of all tasks called by the Optimus pipeline. The default value is 3. Set to 0 to set as non-preemptible.
- A brief explanation of the new `preemptible` option has been added to the README as I, personally, thought it had non-obvious consequences to a user who understands how to run WDL pipelines.
---
### Review Instructions

- Run the pipeline without setting a `preemptible` value.
- Do a metadata query in Swagger with `preemptible` in the includeKey field.
- Ensure that all tasks were attempted with `"preemptible": true`. If `"preemptible": false` appears, I believe it should appear with the value `"attempt": 4` underneath it to prove it was attempted on preemptible machines at least 3 times. Alternatively, ensure that that task with the same shard ID has appeared as `"preemptible": true`.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- I set the `preemptible` default value to be 3 on all tasks called by Optimus. There were a few task files that were not modified. It may be worth changing these to `preemptible = 3` as well, but I was focusing on making the Optimus pipeline preemptible.
- Alternatively, it may be worth re-setting the `preemptible = 0`, as Optimus now always passes a `preemptible` value to these tasks.
- I did not modify the default preemptible values on Picard despite the fact it is called by Optimus, as these were already set to 5. These could be set to 3 for consistency, or left alone, as again--Optimus passes it a `preemptible` value.