### PR TITLE
Boost memory of CalculateGeneMetrics

### DIFF
--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -3,7 +3,7 @@ task CalculateGeneMetrics {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.3"
-  Int machine_mem_mb = 10000
+  Int machine_mem_mb = 20000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "G") * 4)
   Int preemptible = 3


### PR DESCRIPTION
Boost memory of CalculateGeneMetrics to test Adapter Optimus with 4k_pbmc. The current memory (10MB) is not enough for the `CalculateGeneMetrics` task, check a failed run: `curl -X GET "https://cromwell.caas-prod.broadinstitute.org/api/workflows/v1/1d5121a9-7c82-42be-acdd-cf3cbb3f2a66/metadata?includeKey=Failure&expandSubWorkflows=false" -H "accept: application/json" -H "authorization: YOUR_OAUTH_TOKEN"`. 

Theoretically, we should dig into the sctools code base and figure out a way to optimize the `CalculateGeneMetrics` function (https://github.com/HumanCellAtlas/sctools/blob/ad3fbc52e22ed76e6991f389a3cf91536190c456/src/sctools/platform.py#L193). There is already a ticket(GL-67) for that on GL board, @kishorikonwar is working on that.

This PR, is trying to boost the memory for that specific task in a short-sighted way so that we could bypass this error for now.

### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://broadinstitute.atlassian.net/jira/software/projects/GL/boards/528?selectedIssue=GL-128
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Bindly boost the memory for CalculateGeneMetrics task from 10G to 20G.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- The Optimus workflow succeeded after this boost, check workflow `d7923869-af12-4a09-9a5d-fa1aaef84e90` to verify! You could simply use this command: `curl -X GET "https://cromwell.caas-prod.broadinstitute.org/api/workflows/v1/d7923869-af12-4a09-9a5d-fa1aaef84e90/status" -H "accept: application/json" -H "authorization: Bearer YOUR_OAUTH_TOKEN"`

- Note: This PR doesn't change the unit from `MB` to `MiB`. It's out of scope from this PR.
---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] Let Jodi (**jodihir**) know when there is user-facing documentation updates needed!
- [ ] This PR applied the Mint style guide for WDL.
- [ ] This PR has no WDL linting errors reported by [miniwdl](https://github.com/chanzuckerberg/miniwdl)
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
