### PR TITLE
Update cromwell tools version used by PR tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -9,13 +9,14 @@ It compares the results of optimus to the results of the Cell Ranger comparison 
 
 **Testing Logic & Files**
 All files added in this PR are contained within the test directory. 
-- `tests/trigger_test.sh` triggers tests to run within the `humancellatlas/cromwell-tools` docker. This is the test called by Jenkins, and it takes parameters: inputs, wdl, and dependencies. It is designed to trigger tests in the form of WDL workflows. 
+- `tests/trigger_test.sh` triggers tests to run within the `quay.io/broadinstitute/cromwell-tools` docker. This is the test called by Jenkins, and it takes parameters: inputs, wdl, and dependencies. It is designed to trigger tests in the form of WDL workflows.
 - `tests/test_cromwell_workflow.sh` is called by `tests/trigger_test.sh` within the cromwell-tools docker. It calls the provided wdl, waits for it to finish, and checks it's success state. 
 - The scientific and PR tests both contain an "infrastructure wdl" which follows the form `test_${PIPELINE_FOLDER_NAME}_PR` and is composed of two parts:
   - The pipeline workflow, which is imported and run to completion with call caching, which allows the test to run quickly when nothing has changed that would modify the pipeline. 
   - The checker workflow, which, given the outputs of the just-run pipeline, tests them either against the expected outputs (PR) or a range of acceptable outputs (scientific) 
 
-The tests are designed so that any failure results in `exit 1` within the workflow, after the reason is logged to stderr. If a workflow fails due to a result not matching expectations, the result will be logged in the stderr produced by the checker task. If a workflow fails due to not running properly, the user will need to go find the part of the workflow that failed. The jenkins job and cromwell backend will both log the workflow ID so that it is easy to go back and find the failed workflow. 
+The tests are designed so that any failure results in `exit 1` within the workflow, after the reason is logged to stderr. If a workflow fails due to a result not matching expectations, the result will be logged in the stderr produced by the checker task.
+If a workflow fails due to not running properly, the user will need to go find the part of the workflow that failed. The jenkins job and cromwell backend will both log the workflow ID so that it is easy to go back and find the failed workflow.
 
 **Updating workflows that result in scientific changes:**
 In the event that a PR produces a desirable scientific change, the PR test will fail. In order to ensure that future PRs test against the correct "expected values", the test inputs must be updated to reflect the success state of the incoming pipeline. For optimus, this means updating the md5 hashes corresponding to the new output files, which are found in: 
@@ -39,6 +40,6 @@ bash ./test/trigger_test.sh $VAULT_TOKEN $INPUTS_JSON $WDL_FILE $DEPENDENCIES_JS
 Thus, `trigger_test.sh` is run from the current branch, which is cloned as the working directory
 of the jenkins instance. 
 `trigger_test.sh` then runs a docker that maps the current working directory to `/working`.
-Thus, the `WDL_FILE`, and `DEPENDENCIES_JSON` (and any files inside the dependencies with local paths) are interpreted from within the docker as referencing the relevant files on the current branch. 
+Thus, the `WDL_FILE`, and `DEPENDENCIES_JSON` (and any files inside the dependencies with local paths) are interpreted from within the docker as referencing the relevant files on the current branch.
 
 The scientific test does not yet implement the comparison to Cell Ranger, but it does contain a testing script `trigger_scientific_test.sh` which can be run to trigger Optimus to run on the synthetic data. 

--- a/test/test_cromwell_workflow.sh
+++ b/test/test_cromwell_workflow.sh
@@ -11,6 +11,7 @@ OPTIONS_FILE=$6
 DEPENDENCIES_JSON=$7
 # Read list of dependency files into an array to pass to cromwell-tools
 DEPENDENCIES_LIST=$(cat ${DEPENDENCIES_JSON} | python3 -c "import json,sys;obj=json.load(sys.stdin);print(' '.join(obj.values()));")
+echo ${DEPENDENCIES_LIST[@]}
 
 echo "Starting workflow."
 WORKFLOW_HASH=$(cromwell-tools submit \
@@ -25,6 +26,12 @@ WORKFLOW_HASH=$(cromwell-tools submit \
 
 # Get workflow id from cromwell-tools response: {"id": "XXXXX", "status": "Submitted"}
 WORKFLOW_ID=$(echo ${WORKFLOW_HASH} | python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['id']);")
+echo ${WORKFLOW_ID}
+
+# Wait before polling because there is a delay in Cromwell when updating the workflow status
+# Note: This can be removed if cromwell-tools retries this API call internally:
+# https://github.com/broadinstitute/cromwell-tools/issues/62
+sleep 10
 
 echo "Waiting for workflow ${WORKFLOW_ID} to complete..."
 cromwell-tools wait "${WORKFLOW_ID}" \

--- a/test/test_cromwell_workflow.sh
+++ b/test/test_cromwell_workflow.sh
@@ -9,24 +9,28 @@ INPUTS_JSON=$4
 WDL_FILE=$5
 OPTIONS_FILE=$6
 DEPENDENCIES_JSON=$7
+# Read list of dependency files into an array to pass to cromwell-tools
+DEPENDENCIES_LIST=$(cat ${DEPENDENCIES_JSON} | python3 -c "import json,sys;obj=json.load(sys.stdin);print(' '.join(obj.values()));")
 
 echo "Starting workflow."
-WORKFLOW_HASH=$(cromwell-tools run \
+WORKFLOW_HASH=$(cromwell-tools submit \
   --username "${CROMWELL_USER}" \
   --password "${CROMWELL_PASSWORD}" \
-  --cromwell-url "${CROMWELL_URL}" \
-  --inputs-json "${INPUTS_JSON}" \
+  --url "${CROMWELL_URL}" \
+  --inputs_files "${INPUTS_JSON}" \
   --wdl-file "${WDL_FILE}" \
   --options-file "${OPTIONS_FILE}" \
-  --dependencies-json "${DEPENDENCIES_JSON}" \
+  --deps-file ${DEPENDENCIES_LIST[@]} \
 )
 
-echo "Waiting for workflow to complete..."
-cromwell-tools wait \
+# Get workflow id from cromwell-tools response: {"id": "XXXXX", "status": "Submitted"}
+WORKFLOW_ID=$(echo ${WORKFLOW_HASH} | python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['id']);")
+
+echo "Waiting for workflow ${WORKFLOW_ID} to complete..."
+cromwell-tools wait "${WORKFLOW_ID}" \
   --username "${CROMWELL_USER}" \
   --password "${CROMWELL_PASSWORD}" \
-  --cromwell-url "${CROMWELL_URL}" \
-  --workflow-ids "${WORKFLOW_HASH}" \
+  --url "${CROMWELL_URL}" \
   --timeout-minutes 60 \
   --poll-interval-seconds 30
 
@@ -34,13 +38,12 @@ echo "Checking workflow completion status."
 STATUS_RESULT=$(cromwell-tools status \
   --username "${CROMWELL_USER}" \
   --password "${CROMWELL_PASSWORD}" \
-  --cromwell-url "${CROMWELL_URL}" \
-  --workflow-ids "${WORKFLOW_HASH}" \
+  --url "${CROMWELL_URL}" \
+  --uuid "${WORKFLOW_ID}" \
 )
-echo "${STATUS_RESULT}"
 
 # get the status alone; cromwell tools is a bit more verbose
-STATUS=$(echo "${STATUS_RESULT}" | awk '{print $NF}')
+STATUS=$(echo ${STATUS_RESULT} | python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['status']);")
 
 if [ "${STATUS}" == "Succeeded" ]; then
   echo "Test Successful. Workflow outputs matched expected values."

--- a/test/trigger_test.sh
+++ b/test/trigger_test.sh
@@ -26,7 +26,7 @@ docker run --rm \
   -v ${WD}:/working \
   -w /working \
   --privileged \
-  humancellatlas/cromwell-tools:1.0.1 \
+  quay.io/broadinstitute/cromwell-tools:v1.1.1 \
   /working/test/test_cromwell_workflow.sh \
     "${CROMWELL_USER}" \
     "${CROMWELL_PASSWORD}" \


### PR DESCRIPTION
### Purpose
The pipeline tests for SmartSeq2 and Optimus were using a very old version of the cromwell-tools docker image. 

Fixes: https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-66

---
### Changes
This PR updates the PR tests to make use the latest version of cromwell tools.

---
### Review Instructions
Run the test script:
```
VAULT_TOKEN=$(cat $HOME/.vault-token)
INPUTS_JSON="/working/test/smartseq2_single_sample/pr/test_inputs.json"
WDL_FILE="/working/test/smartseq2_single_sample/pr/test_smartseq2_single_sample_PR.wdl"
DEPENDENCIES_JSON="/working/test/smartseq2_single_sample/pr/dependencies.json"
bash ./test/trigger_test.sh $VAULT_TOKEN $INPUTS_JSON $WDL_FILE $DEPENDENCIES_JSON
```
---
### PR Checklist
_Please ensure the following when opening a PR:_

- [x] This PR added or updated tests.
- [x] This PR updated docstrings or documentation.
- [ ] Let Jodi (**jodihir**) know when there is user-facing documentation updates needed!
- [ ] This PR applied the Mint style guide for WDL.
- [ ] This PR has no WDL linting errors reported by [miniwdl](https://github.com/chanzuckerberg/miniwdl)
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
The scientific tests also use an old version of cromwell-tools, but they are not connected to any CI system and have not been updated in the last year. They will likely need to be re-visited to make sure they are testing all the new additions to the pipelines, so they are not included in this PR.
