### PR TITLE
Disable preemptible for some time-consuming tasks.

### DIFF
--- a/library/tasks/Attach10xBarcodes.wdl
+++ b/library/tasks/Attach10xBarcodes.wdl
@@ -10,7 +10,8 @@ task Attach10xBarcodes {
   Int cpu = 2
   # estimate that bam is approximately the size of all inputs plus 50%
   Int disk = ceil((size(r2_unmapped_bam, "G") + size(r1_fastq, "G") + if (defined(i1_fastq)) then size(i1_fastq, "G") else 0) * 2.5)
-  Int preemptible = 3
+  # by default request non preemptible machine to make sure the slow attach barcodes step completes
+  Int preemptible = 0
 
   meta {
     description: "attaches barcodes found in r1 (forward) and i1 (index) fastq files to corresponding reads in the r2 (reverse) bam file"

--- a/library/tasks/MergeSortBam.wdl
+++ b/library/tasks/MergeSortBam.wdl
@@ -12,7 +12,8 @@ task MergeSortBamFiles {
   Int cpu = 1
   # default to 500GB of space
   Int disk = 500
-  Int preemptible = 3
+  # by default request non preemptible machine to make sure the slow mergsort step completes
+  Int preemptible = 0
 
   meta {
     description: "Merge multiple bam files in the specified sort order"

--- a/library/tasks/SplitBamByCellBarcode.wdl
+++ b/library/tasks/SplitBamByCellBarcode.wdl
@@ -8,7 +8,8 @@ task SplitBamByCellBarcode {
   Int cpu = 1
   # estimate that bam is approximately equal in size to the input bam, add 20% buffer
   Int disk = ceil(size(bam_input, "G") * 2.2)
-  Int preemptible = 3
+  # by default request non preemptible machine to make sure the slow cell barcode split step completes
+  Int preemptible = 0
 
   meta {
     description: "Splits a bam file into chunks of size_in_mb, guaranteeing that all information for each cell is fully contained in only one of the chunks"

--- a/library/tasks/StarAlignBamSingleEnd.wdl
+++ b/library/tasks/StarAlignBamSingleEnd.wdl
@@ -8,7 +8,8 @@ task StarAlignBamSingleEnd {
   Int cpu = 16
   # multiply input size by 2.2 to account for output bam file + 20% overhead, add size of reference.
   Int disk = ceil((size(tar_star_reference, "G") * 2) + (size(bam_input, "G") * 2.2))
-  Int preemptible = 3
+  # by default request non preemptible machine to make sure the slow star alignment step completes
+  Int preemptible = 0
 
   meta {
     description: "Aligns reads in bam_input to the reference genome in tar_star_reference"

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -41,6 +41,11 @@ workflow Optimus {
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
 
+  # this pipeline does not set any preemptible varibles and only relies on the task-level preemptible settings
+  # you could override the tasklevel preemptible settings by passing it as one of the workflows inputs
+  # for example: `"Optimus.StarAlign.preemptible": 3` will let the StarAlign task, which by default disables the
+  # usage of preemptible machines, attempt to request for preemptible instance up to 3 times. 
+
   parameter_meta {
     r1_fastq: "forward read, contains cell barcodes and molecule barcodes"
     r2_fastq: "reverse read, contains cDNA fragment generated from captured mRNA"

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -41,11 +41,6 @@ workflow Optimus {
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
 
-  # try to use preemptible VMs for 3 times
-  Int preemptible = 3
-  # do not use preemptible VMs
-  Int no_preemptible = 0
-
   parameter_meta {
     r1_fastq: "forward read, contains cell barcodes and molecule barcodes"
     r2_fastq: "reverse read, contains cDNA fragment generated from captured mRNA"
@@ -57,7 +52,6 @@ workflow Optimus {
     whitelist: "10x genomics cell barcode whitelist for 10x V2"
     fastq_suffix: "when running in green box, need to add '.gz' for picard to detect the compression"
     output_zarr: "whether to run the taks that converts the outputs to Zarr format, by default it's true"
-    preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
   }
 
   scatter (index in indices) {

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -41,7 +41,10 @@ workflow Optimus {
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
 
+  # try to use preemptible VMs for 3 times
   Int preemptible = 3
+  # do not use preemptible VMs
+  Int no_preemptible = 0
 
   parameter_meta {
     r1_fastq: "forward read, contains cell barcodes and molecule barcodes"
@@ -75,7 +78,7 @@ workflow Optimus {
           i1_fastq = non_optional_i1_fastq[index],
           r2_unmapped_bam = FastqToUBam.bam_output,
           whitelist = whitelist,
-          preemptible = preemptible
+          preemptible = no_preemptible
       }
     }
 
@@ -86,7 +89,7 @@ workflow Optimus {
           r1_fastq = r1_fastq[index],
           r2_unmapped_bam = FastqToUBam.bam_output,
           whitelist = whitelist,
-          preemptible = preemptible
+          preemptible = no_preemptible
       }
     }
 
@@ -111,7 +114,7 @@ workflow Optimus {
       input:
         bam_input = bam,
         tar_star_reference = tar_star_reference,
-        preemptible = preemptible
+        preemptible = no_preemptible
     }
 
     call TagGeneExon.TagGeneExon as TagGenes {


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://broadinstitute.atlassian.net/jira/software/projects/GL/boards/528?selectedIssue=GL-166
- Just looking at this run: https://job-manager.caas-prod.broadinstitute.org/jobs/b3f61b06-635c-466e-997c-2a77a313c6d1?q=caas-collection-name%3Dlira-test%26bundle-uuid%3D00ba4f21-7a70-4517-8bdd-a9ac9aa4c444 we can tell that it's not practical to use the same `preemptible` settings for all of the tasks in Optimus. The above run was only on a very small dataset, if we run Optimus on larger datasets, things will get worse. We need finer control over the settings.

---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Add another `no_preemptible` switch to the Optimus pipeline, so we can disable `preemptible` on specific steps. Downside: not atomic enough. Especially when you run the Optimus within an Adapter workflow, there's no way you can change the pre-defined settings except modifying the pipeline itself.

---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- This PR is mutually exclusive to the https://github.com/HumanCellAtlas/skylab/pull/174, only one of them can be merged🥇 ! 

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] Let Jodi (**jodihir**) know when there is user-facing documentation updates needed!
- [ ] This PR applied the Mint style guide for WDL.
- [ ] This PR has no WDL linting errors reported by [miniwdl](https://github.com/chanzuckerberg/miniwdl)
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
