### PR TITLE
Use pipeline-surge for running pipelines in caas-prod launched by

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -17,18 +17,6 @@ pullapprove_conditions:
   unmet_status: failure
   explanation: "Snyk tests must pass before review starts"
 
-#- condition: "'Jenkins Optimus Tests' in statuses.successful"
-#  unmet_status: failure
-#  explanation: "Jenkins Optimus tests must pass before review starts"
-#
-#- condition: "'Jenkins SS2 Tests' in statuses.successful"
-#  unmet_status: failure
-#  explanation: "Jenkins SS2 tests must pass before review starts"
-
-- condition: "'Jenkins Integration Tests' in statuses.successful"
-  unmet_status: failure
-  explanation: "Jenkins Integration tests must pass before review starts"
-
 groups:
   pullapprove-admins:
     conditions:

--- a/test/trigger_test.sh
+++ b/test/trigger_test.sh
@@ -19,7 +19,7 @@ CROMWELL_KEY_FILE="caas-prod.json"
 
 OPTIONS_FILE="https://raw.githubusercontent.com/HumanCellAtlas/skylab/master/test/options.json"
 CROMWELL_URL="https://cromwell.caas-prod.broadinstitute.org"
-COLLECTION="lira-dev"
+COLLECTION="pipeline-surge"
 
 echo "Running test"
 docker run --rm \


### PR DESCRIPTION
### Purpose

Need to use a different test collection for running workflows from circle-ci

