### PR TITLE
Use disks not disk in runtime block

### DIFF
--- a/library/tasks/ScatterBam.wdl
+++ b/library/tasks/ScatterBam.wdl
@@ -19,7 +19,7 @@ task ScatterBam {
   }
 
   runtime {
-    disk: "local-disk ${disk_size} HDD"
+    disks: "local-disk ${disk_size} HDD"
     cpu: 2
     memory: "7.5 GiB"
     docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.3-1513176735"


### PR DESCRIPTION
### Purpose
The `runtime` block in WDL needs `disks`, not `disk`. This did not fail in the PR tests because the data is small enough to fit in the default 10 GiB SSD.

### Changes
Changed ScatterBam to use `disks` and provision the correct amount of disk.