### PR TITLE
GH-282: move max retries out of wdls

### DIFF
--- a/library/tasks/GroupMetricsOutputs.wdl
+++ b/library/tasks/GroupMetricsOutputs.wdl
@@ -11,8 +11,7 @@ task GroupQCOutputs {
   Int cpu = 1
   Int disk_space = 20 
   Int preemptible = 5
-  Int max_retries = 0
-  
+
   meta {
     description: "This task will group the Picard metrics"
   }
@@ -28,7 +27,6 @@ task GroupQCOutputs {
     cpu: "(optional) the number of cpus to provision for this task"
     disk_space: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
  command {
     set -e
@@ -49,6 +47,5 @@ task GroupQCOutputs {
     disks: "local-disk ${disk_space} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 }

--- a/library/tasks/HISAT2.wdl
+++ b/library/tasks/HISAT2.wdl
@@ -14,7 +14,6 @@ task HISAT2PairedEnd {
   # Need room for unsorted + sorted bam + temp sorting space + zipped and unzipped ref. Add 10 GiB buffer.
   Int disk = ceil((size(fastq1, "GiB") + size(fastq2, "GiB")) * 100 + size(hisat2_ref, "GiB") * 2 + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "HISAT2 alignment task will align paired-end fastq reads to reference genome."
@@ -32,7 +31,6 @@ task HISAT2PairedEnd {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -84,7 +82,6 @@ task HISAT2PairedEnd {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 
   output {
@@ -111,7 +108,6 @@ task HISAT2RSEM {
   # Need room for unsorted + sorted bam + temp sorting space + zipped and unzipped ref. Add 10 GiB buffer.
   Int disk = ceil((size(fastq1, "GiB") + size(fastq2, "GiB")) * 100 + size(hisat2_ref, "GiB") * 2 + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This HISAT2 alignment task will align paired-end fastq reads to transcriptome only. "
@@ -129,7 +125,6 @@ task HISAT2RSEM {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -187,7 +182,6 @@ task HISAT2RSEM {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 
   output {
@@ -212,7 +206,6 @@ task HISAT2SingleEnd {
   # Need room for unsorted + sorted bam + temp sorting space + zipped and unzipped ref. Add 10 GiB buffer.
   Int disk = ceil((size(fastq, "GiB") * 100) + size(hisat2_ref, "GiB") * 2 + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This HISAT2 alignment task will align single-end fastq reads to reference genome."
@@ -257,7 +250,6 @@ task HISAT2SingleEnd {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 
   output {
@@ -327,7 +319,6 @@ task HISAT2RSEMSingleEnd {
   Int cpu = 4
   Int disk = ceil((size(fastq, "GiB")) * 100 + size(hisat2_ref, "GiB") * 2 + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This HISAT2 alignment task will align paired-end fastq reads to transcriptome only. "
@@ -344,7 +335,6 @@ task HISAT2RSEMSingleEnd {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -395,7 +385,6 @@ task HISAT2RSEMSingleEnd {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 
   output {

--- a/library/tasks/Picard.wdl
+++ b/library/tasks/Picard.wdl
@@ -93,7 +93,6 @@ task CollectMultipleMetrics {
   # use provided disk number or dynamically size on our own, with 10GiB of additional disk
   Int disk = ceil(size(aligned_bam, "GiB") + size(genome_ref_fasta, "GiB") + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This Picard task will collect multiple QC metrics, such as CollectAlignmentSummaryMetrics and CollectInsertSizeMetrics."
@@ -108,7 +107,6 @@ task CollectMultipleMetrics {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -137,7 +135,6 @@ task CollectMultipleMetrics {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
   
   output {
@@ -177,7 +174,6 @@ task CollectRnaMetrics {
   # use provided disk number or dynamically size on our own, with 10GiB of additional disk
   Int disk = ceil(size(aligned_bam, "GiB") + size(ref_flat, "GiB") + size(rrna_intervals, "GiB") + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This Picard task will collect RnaSeqMetrics."
@@ -194,7 +190,6 @@ task CollectRnaMetrics {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
   
   command {
@@ -217,7 +212,6 @@ task CollectRnaMetrics {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
 
   output {
@@ -240,7 +234,6 @@ task CollectDuplicationMetrics {
   # use provided disk number or dynamically size on our own, with 10GiB of additional disk
   Int disk = ceil(size(aligned_bam, "GiB") + 10)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This Picard task will collect alignment DuplicationMetrics."
@@ -254,7 +247,6 @@ task CollectDuplicationMetrics {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
   
   command {
@@ -273,7 +265,6 @@ task CollectDuplicationMetrics {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    maxRetries: max_retries
   }
   
   output {

--- a/library/tasks/RSEM.wdl
+++ b/library/tasks/RSEM.wdl
@@ -11,7 +11,6 @@ task RSEMExpression {
   # use provided disk number or dynamically size on our own, with 20GiB of additional disk
   Int disk = ceil(size(trans_aligned_bam, "GiB") + size(rsem_genome, "GiB") + 20)
   Int preemptible = 5
-  Int max_retries = 0
 
   meta {
     description: "This task will quantify gene expression matrix by using RSEM. The output include gene-level and isoform-level results."
@@ -26,7 +25,6 @@ task RSEMExpression {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -51,7 +49,6 @@ task RSEMExpression {
     disks: "local-disk ${disk} HDD"
     cpu: cpu
     preemptible: preemptible
-    max_retries: max_retries
   }
 
   output {

--- a/library/tasks/ZarrUtils.wdl
+++ b/library/tasks/ZarrUtils.wdl
@@ -20,7 +20,6 @@ task SmartSeq2ZarrConversion {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {
@@ -89,7 +88,6 @@ task OptimusZarrConversion {
     cpu: "(optional) the number of cpus to provision for this task"
     disk: "(optional) the amount of disk space (GiB) to provision for this task"
     preemptible: "(optional) if non-zero, request a pre-emptible instance and allow for this number of preemptions before running the task on a non preemptible machine"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
   }
 
   command {

--- a/pipelines/cellranger/cellranger.wdl
+++ b/pipelines/cellranger/cellranger.wdl
@@ -16,7 +16,6 @@ workflow CellRanger {
     Int boot_disk_size_gb = 12
     String disk_space = "400"
     Int cpu = 64
-    Int max_retries = 0
 
     parameter_meta {
         sample_id: "Name of sample to run CellRanger count on"
@@ -28,7 +27,6 @@ workflow CellRanger {
         boot_disk_size_gb: "Size of disk (GB) where the docker image is booted by the Cromwell VM"
         disk_space: "Amount of disk space (GB) to allocate to the Cromwell VM"
         cpu: "The minimum number of cores to use for the Cromwell VM"
-        max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
     }
 
     call cellranger_count {
@@ -41,8 +39,7 @@ workflow CellRanger {
         memory = memory,
         boot_disk_size_gb = boot_disk_size_gb,
         disk_space = disk_space,
-        cpu = cpu,
-        max_retries = max_retries
+        cpu = cpu
    }
 
    output {
@@ -75,7 +72,6 @@ task cellranger_count {
     Int boot_disk_size_gb
     String disk_space
     Int cpu
-    Int max_retries = 0
 
     command {
         set -e
@@ -117,7 +113,6 @@ task cellranger_count {
         bootDiskSizeGb: boot_disk_size_gb
         disks: "local-disk " + disk_space + " HDD"
         cpu: cpu
-        max_retries: max_retries
     }
 
     output {

--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -27,7 +27,6 @@ workflow SmartSeq2SingleCell {
   String output_name
   File fastq1
   File fastq2
-  Int max_retries = 0
 
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
@@ -46,7 +45,6 @@ workflow SmartSeq2SingleCell {
     output_name: "Output name, can include path"
     fastq1: "R1 in paired end reads"
     fastq2: "R2 in paired end reads"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
     output_zarr: "whether to run the taks that converts the outputs to Zarr format, by default it's true"
   }
 
@@ -60,7 +58,6 @@ workflow SmartSeq2SingleCell {
       ref_name = hisat2_ref_name,
       sample_name = sample_name,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   call Picard.CollectMultipleMetrics {
@@ -68,7 +65,6 @@ workflow SmartSeq2SingleCell {
       aligned_bam = HISAT2PairedEnd.output_bam,
       genome_ref_fasta = genome_ref_fasta,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   call Picard.CollectRnaMetrics {
@@ -78,14 +74,12 @@ workflow SmartSeq2SingleCell {
       rrna_intervals = rrna_intervals,
       output_basename = quality_control_output_basename,
       stranded = stranded,
-      max_retries = max_retries,
   }
 
   call Picard.CollectDuplicationMetrics {
     input:
       aligned_bam = HISAT2PairedEnd.output_bam,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   String data_output_basename = output_name + "_rsem"
@@ -98,7 +92,6 @@ workflow SmartSeq2SingleCell {
       ref_name = hisat2_ref_trans_name,
       sample_name = sample_name,
       output_basename = data_output_basename,
-      max_retries = max_retries,
   }
 
   call RSEM.RSEMExpression {
@@ -106,7 +99,6 @@ workflow SmartSeq2SingleCell {
       trans_aligned_bam = HISAT2Transcriptome.output_bam,
       rsem_genome = rsem_ref_index,
       output_basename = data_output_basename,
-      max_retries = max_retries,
       is_paired = true
   }
 

--- a/pipelines/smartseq2_single_sample_unpaired/SmartSeq2SingleSampleUnpaired.wdl
+++ b/pipelines/smartseq2_single_sample_unpaired/SmartSeq2SingleSampleUnpaired.wdl
@@ -26,7 +26,6 @@ workflow SmartSeq2SingleCellUnpaired {
   String sample_name
   String output_name
   File fastq
-  Int max_retries = 0
 
   # whether to convert the outputs to Zarr format, by default it's set to true
   Boolean output_zarr = true
@@ -44,7 +43,6 @@ workflow SmartSeq2SingleCellUnpaired {
     sample_name: "Sample name or Cell ID"
     output_name: "Output name, can include path"
     fastq: "Single end reads"
-    max_retries: "(optional) retry this number of times if task fails -- use with caution, see skylab README for details"
     output_zarr: "whether to run the taks that converts the outputs to Zarr format, by default it's true"
   }
 
@@ -57,7 +55,6 @@ workflow SmartSeq2SingleCellUnpaired {
       ref_name = hisat2_ref_name,
       sample_name = sample_name,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   call Picard.CollectMultipleMetrics {
@@ -65,7 +62,6 @@ workflow SmartSeq2SingleCellUnpaired {
       aligned_bam = HISAT2SingleEnd.output_bam,
       genome_ref_fasta = genome_ref_fasta,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   call Picard.CollectRnaMetrics {
@@ -75,14 +71,12 @@ workflow SmartSeq2SingleCellUnpaired {
       rrna_intervals = rrna_intervals,
       output_basename = quality_control_output_basename,
       stranded = stranded,
-      max_retries = max_retries,
   }
 
   call Picard.CollectDuplicationMetrics {
     input:
       aligned_bam = HISAT2SingleEnd.output_bam,
       output_basename = quality_control_output_basename,
-      max_retries = max_retries,
   }
 
   String data_output_basename = output_name + "_rsem"
@@ -94,7 +88,6 @@ workflow SmartSeq2SingleCellUnpaired {
       ref_name = hisat2_ref_trans_name,
       sample_name = sample_name,
       output_basename = data_output_basename,
-      max_retries = max_retries,
   }
 
   call RSEM.RSEMExpression {
@@ -102,7 +95,6 @@ workflow SmartSeq2SingleCellUnpaired {
       trans_aligned_bam = HISAT2Transcriptome.output_bam,
       rsem_genome = rsem_ref_index,
       output_basename = data_output_basename,
-      max_retries = max_retries,
       is_paired = false
   }
 


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->
Ticket: [JIRA](https://broadinstitute.atlassian.net/browse/GH-282)

Instead of passing in the maxRetries runtime parameter into the workflow, and then passing that into every task, define it in the workflow options file.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- maxRetries runtime parameter moved out of wdl & task inputs and into cromwell options by way of Lira config
[parallel changes in lira](https://github.com/HumanCellAtlas/lira/pull/168)
[parallel changes in pipeline-tools](https://github.com/HumanCellAtlas/pipeline-tools/pull/151)

Note: This change needs to be merged in at the same time as the pipeline-tools change, otherwise the mintegration tests that run off of our PRs will break.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
