### PR TITLE
HISAT2.wdl: replace output command substitutions with explicit fifo/wait

### DIFF
--- a/library/tasks/HISAT2.wdl
+++ b/library/tasks/HISAT2.wdl
@@ -62,6 +62,8 @@ task HISAT2PairedEnd {
     # --seed to fix pseudo-random number and in order to produce deterministics results
     # --secondary reports secondary alignments for multimapping reads. -k 10
     # searches for up to 10 primary alignments for each read
+    mkfifo samtools_pipe
+    samtools view -1 -h -o "${output_basename}_unsorted.bam" samtools_pipe & pid=$!
     hisat2 -t \
       -x ${ref_name}/${ref_name} \
       -1 $FQ1 \
@@ -73,7 +75,8 @@ task HISAT2PairedEnd {
       --seed 12345 \
       -k 10 \
       --secondary \
-      -p ${cpu} -S >(samtools view -1 -h -o ${output_basename}_unsorted.bam)
+      -p ${cpu} -S samtools_pipe
+    wait $pid
     samtools sort -@ ${cpu} -O bam -o "${output_basename}.bam" "${output_basename}_unsorted.bam"
     samtools index "${output_basename}.bam"
   }
@@ -158,6 +161,8 @@ task HISAT2RSEM {
     # with no-splice-alignment no-softclip no-mixed options on, HISAT2 will only output concordant alignment without soft-cliping
     # --rdg 99999999,99999999 and --rfg 99999999,99999999 will set an infinite penalty to alignments with indels.
     # As a result, alignments with gaps or deletions are excluded.
+    mkfifo samtools_pipe
+    samtools view -1 -h -o "${output_basename}.bam" samtools_pipe & pid=$!
     hisat2 -t \
       -x ${ref_name}/${ref_name} \
       -1 $FQ1 \
@@ -178,7 +183,8 @@ task HISAT2RSEM {
       --rfg 99999999,99999999 \
       --no-spliced-alignment \
       --seed 12345 \
-      -p ${cpu} -S >(samtools view -1 -h -o ${output_basename}.bam)
+      -p ${cpu} -S samtools_pipe
+    wait $pid
   }
 
   runtime {
@@ -236,6 +242,8 @@ task HISAT2SingleEnd {
     tar --no-same-owner -xvf "${hisat2_ref}"
 
     # The parameters for this task are copied from the HISAT2PairedEnd task.
+    mkfifo samtools_pipe
+    samtools view -1 -h -o "${output_basename}_unsorted.bam" samtools_pipe & pid=$!
     hisat2 -t \
       -x ${ref_name}/${ref_name} \
       -U ${fastq} \
@@ -246,7 +254,8 @@ task HISAT2SingleEnd {
       --seed 12345 \
       -k 10 \
       --secondary \
-      -p ${cpu} -S >(samtools view -1 -h -o ${output_basename}_unsorted.bam)
+      -p ${cpu} -S samtools_pipe
+    wait $pid
     samtools sort -@ ${cpu} -O bam -o "${output_basename}.bam" "${output_basename}_unsorted.bam"
     samtools index "${output_basename}.bam"
   }
@@ -367,6 +376,8 @@ task HISAT2RSEMSingleEnd {
     # with no-splice-alignment no-softclip no-mixed options on, HISAT2 will only output concordant alignment without soft-cliping
     # --rdg 99999999,99999999 and --rfg 99999999,99999999 will set an infinite penalty to alignments with indels.
     # As a result, alignments with gaps or deletions are excluded.
+    mkfifo samtoolspipe
+    samtools view -1 -h -o "${output_basename}.bam" samtools_pipe & pid=$!
     hisat2 -t \
       -x ${ref_name}/${ref_name} \
       -U $FQ \
@@ -386,7 +397,8 @@ task HISAT2RSEMSingleEnd {
       --rfg 99999999,99999999 \
       --no-spliced-alignment \
       --seed 12345 \
-      -p ${cpu} -S >(samtools view -1 -h -o ${output_basename}.bam)
+      -p ${cpu} -S samtools_pipe
+    wait $pid
   }
 
   runtime {


### PR DESCRIPTION
The hisat2 tasks stream output into samtools to avoid having to materialize a giant text SAM file on the scratch disk. This is a good idea but it's implemented in a slightly risky way, using an output command substitution like `hisat2 ... -S >(samtools view -o output.bam ...)`. In this construct samtools is spawned as a background process, and bash does *not* wait for it before proceeding to the next command or exiting at the end of the script. Furthermore according to [this Q&A](https://unix.stackexchange.com/questions/403783/the-process-substitution-output-is-out-of-the-order) it does not even *provide a way* to wait for it!

This creates a race condition where the next step is liable to start reading a partial BAM file, including the runtime system potentially outputting a truncated file (cf. https://github.com/chanzuckerberg/miniwdl/issues/211).

Here we replace the output command substitutions with a less-elegant but hopefully reliable construct, which allows us to explicitly wait for samtools before proceeding.