### PR TITLE
Set ScatterBam docker to be a public Picard docker.

### DIFF
--- a/docker/picard/Dockerfile
+++ b/docker/picard/Dockerfile
@@ -1,14 +1,14 @@
 FROM openjdk:8-jre
 
-LABEL maintainer="Jishu Xu <jishuxu@broadinstitute.org>" \
+LABEL maintainer="Green Lantern <lantern@broadinstitute.org>" \
   software="Picard" \
-  version="2.10.2" \
+  version="2.11.1" \
   description="A set of command line tools (in Java) for manipulating high-throughput sequencing (HTS) data and formats such as SAM/BAM/CRAM and VCF." \
   website="http://broadinstitute.github.io/picard"
 
 # Please follow the below instructions to invoke picard when you are using this docker image:
 # java jvm-args -jar /usr/picard/picard.jar PicardToolName OPTION1=value1 OPTION2=value2...
-ENV version 2.18.2
+ENV version 2.20.4
 WORKDIR /usr/picard
 ADD https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar ./picard.jar
 

--- a/library/tasks/ScatterBam.wdl
+++ b/library/tasks/ScatterBam.wdl
@@ -1,3 +1,4 @@
+
 task ScatterBam {
 
   File bam_to_scatter
@@ -6,7 +7,7 @@ task ScatterBam {
 
   command <<<
     mkdir scattered_bams
-    java -Xms7g -jar /usr/gitc/picard.jar \
+    java -Xms7g -jar /usr/picard/picard.jar \
       SplitSamByNumberOfReads \
       INPUT=${bam_to_scatter} \
       SPLIT_TO_N_FILES=${scatter_width} \
@@ -22,6 +23,6 @@ task ScatterBam {
     disks: "local-disk ${disk_size} HDD"
     cpu: 2
     memory: "7.5 GiB"
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.3.3-1513176735"
+    docker: "quay.io/humancellatlas/secondary-analysis-picard:2.20.4"
   }
 }

--- a/library/tasks/ScatterBam.wdl
+++ b/library/tasks/ScatterBam.wdl
@@ -1,4 +1,3 @@
-
 task ScatterBam {
 
   File bam_to_scatter


### PR DESCRIPTION
### Purpose
- Some users are unable to use the Optimus pipeline due to docker image restrictions.
- We shouldn't be using the docker image used previously in ScatterBam.
- [Related Issue: GL-473](https://broadinstitute.atlassian.net/browse/GL-473)

### Changes
- Update picard Dockerfile to represent new maintainer & version.
- Change ScatterBam to use a just-created quay.io picard image.

### Review Instructions
- Run Optimus, and get the same-enough results as using the old ScatterBam docker image.
