### PR TITLE
Increase RunEmptyDrops memory

### DIFF
--- a/library/tasks/RunEmptyDrops.wdl
+++ b/library/tasks/RunEmptyDrops.wdl
@@ -13,7 +13,7 @@ task RunEmptyDrops {
 
     # runtime values
     String docker = "quay.io/humancellatlas/secondary-analysis-dropletutils:0.1.1"
-    Int machine_mem_mb = 4400
+    Int machine_mem_mb = 10000
     Int cpu = 1
     Int disk = 20
     Int preemptible = 3


### PR DESCRIPTION
### Purpose
One of the Fetal/Maternal interface datasets in production is failing because it needs at least 6GB of memory. As suggested by @barkasn, this is a very short-running task so we can increase the memory to 10GiB and then make this more efficient later. 
