### PR TITLE
remove the passing build test from the requirements for pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,9 +1,6 @@
 version: 3
 
 pullapprove_conditions:
-- condition: "'ci/circleci: build' in statuses.successful"
-  unmet_status: failure
-  explanation: "Circle CI tests must pass before review starts"
 
 - condition: "'ci/circleci: test_emptyDropsWrapper' in statuses.successful"
   unmet_status: failure


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- The build test is being split into multiple test entries as portability tests PR #234 . Requiring a passing build test will no longer make sense. We will add the individual tests sback in at a later time. 

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Remove the build test from the pullapprove requirements 

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
