### PR TITLE
Revert the preemptible flag and bump the memory crazily.

### DIFF
--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -45,10 +45,10 @@ task CalculateCellMetrics {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.3"
-  Int machine_mem_mb = 3850
+  Int machine_mem_mb = 16000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "Gi") * 2)
-  Int preemptible = 0
+  Int preemptible = 3
 
   meta {
     description: "Calculate cell metrics from the reads in bam_input."


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- No issue is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Bump the memory for `CalculateCellMetrics`. 
- I did not change the version since I'm planning to perform a "git re-tag" with the same version number later.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
