### PR TITLE
Increase memory for some optimus tasks

### DIFF
--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -45,7 +45,7 @@ task CalculateCellMetrics {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.3"
-  Int machine_mem_mb = 16000
+  Int machine_mem_mb = 22000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "Gi") * 2)
   Int preemptible = 3

--- a/library/tasks/TagSortBam.wdl
+++ b/library/tasks/TagSortBam.wdl
@@ -3,7 +3,7 @@ task CellSortBam {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
-  Int machine_mem_mb = 44000
+  Int machine_mem_mb = 100000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "Gi") * 8)
   Int preemptible = 3
@@ -45,7 +45,7 @@ task GeneSortBam {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.2"
-  Int machine_mem_mb = 44000
+  Int machine_mem_mb = 100000
   Int cpu = 2
   Int disk = ceil(size(bam_input, "Gi") * 4)
   Int preemptible = 3

--- a/library/tasks/UmiCorrection.wdl
+++ b/library/tasks/UmiCorrection.wdl
@@ -9,7 +9,7 @@ task CorrectUMItools {
     String groupout_filename = "groupout.tsv"
 
     ## TODO: Optimize these values
-    Int machine_mem_mb = 11000
+    Int machine_mem_mb = 16000
     Int cpu = 1
     Int disk = ceil(size(bam_input, "Gi") * 6) + 50
     Int preemptible = 3

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -19,7 +19,7 @@ workflow Optimus {
     description: "The optimus 3' pipeline processes 10x genomics sequencing data based on the v2 chemistry. It corrects cell barcodes and UMIs, aligns reads, marks duplicates, and returns data as alignments in BAM format and as counts in sparse matrix exchange format."
   }
   # version of this pipeline
-  String version = "optimus_v1.3.3"
+  String version = "optimus_v1.3.4"
 
   # Sequencing data inputs
   Array[File] r1_fastq


### PR DESCRIPTION
### Purpose
An Optimus production workflow failed in several tasks due to lack of sufficient memory: https://job-manager.caas-prod.broadinstitute.org/jobs/a9005a06-b9e1-4788-87dd-a49f8194dec7

### Changes
Increased memory for `CellSortBam`, `GeneSortBam`, `CalculateCellMetrics` and `CorrectUMItools`

Note: In the future, it would be great to have a dynamic "multiplier" parameter so it is easier to re-run workflows with increased memory/disk-space as suggested by @pshapiro4broad :octocat:   
