### PR TITLE
Increase CalculateCellMetrics memory

### DIFF
--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -45,7 +45,7 @@ task CalculateCellMetrics {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.3"
-  Int machine_mem_mb = 30000
+  Int machine_mem_mb = 45000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "Gi") * 2)
   Int preemptible = 3

--- a/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
+++ b/library/tasks/SequenceDataWithMoleculeTagMetrics.wdl
@@ -45,7 +45,7 @@ task CalculateCellMetrics {
 
   # runtime values
   String docker = "quay.io/humancellatlas/secondary-analysis-sctools:v0.3.3"
-  Int machine_mem_mb = 22000
+  Int machine_mem_mb = 30000
   Int cpu = 1
   Int disk = ceil(size(bam_input, "Gi") * 2)
   Int preemptible = 3


### PR DESCRIPTION
### Purpose
Unfortunately a few shards are still failing in the CalculateCellMetrics task for the [production workflow ](https://job-manager.caas-prod.broadinstitute.org/jobs/507af54f-6913-4f44-9023-b1162e0274ec?q=caas-collection-name%3Dlira-prod)so this PR increases the memory even more.