### PR TITLE
Remove hard-coded pipeline version from WDLs

### DIFF
--- a/pipelines/cellranger/cellranger.wdl
+++ b/pipelines/cellranger/cellranger.wdl
@@ -2,8 +2,6 @@ workflow CellRanger {
     meta {
         description: "Analyze 3' single-cell RNA-seq data using the 10X Genomics Cellranger pipeline."
     }
-    # version of this pipeline
-    String version = "cellranger_v1.0.2"
 
     String sample_id
     Array[File] fastqs
@@ -43,9 +41,6 @@ workflow CellRanger {
    }
 
    output {
-       # version of this pipeline
-       String pipeline_version = version
-
        File qc = cellranger_count.qc
        File sorted_bam = cellranger_count.sorted_bam
        File sorted_bam_index = cellranger_count.sorted_bam_index

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -19,8 +19,6 @@ workflow Optimus {
   meta {
     description: "The optimus 3' pipeline processes 10x genomics sequencing data based on the v2 chemistry. It corrects cell barcodes and UMIs, aligns reads, marks duplicates, and returns data as alignments in BAM format and as counts in sparse matrix exchange format."
   }
-  # version of this pipeline
-  String version = "optimus_v1.3.6"
 
   # Sequencing data inputs
   Array[File] r1_fastq
@@ -245,9 +243,6 @@ workflow Optimus {
   }
 
   output {
-    # version of this pipeline
-    String pipeline_version = version
-
     File bam = MergeSorted.output_bam
     File matrix = MergeCountFiles.sparse_count_matrix
     File matrix_row_index = MergeCountFiles.row_index

--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -8,8 +8,6 @@ workflow SmartSeq2SingleCell {
   meta {
     description: "Process SmartSeq2 scRNA-Seq data, include reads alignment, QC metrics collection, and gene expression quantitication"
   }
-  # version of this pipeline
-  String version = "smartseq2_v2.4.0"
   # load annotation
   File genome_ref_fasta
   File rrna_intervals
@@ -122,8 +120,6 @@ workflow SmartSeq2SingleCell {
 
 
   output {
-    # version of this pipeline
-    String pipeline_version = version
     # quality control outputs
     File aligned_bam = HISAT2PairedEnd.output_bam
     File bam_index = HISAT2PairedEnd.bam_index

--- a/pipelines/smartseq2_single_sample_unpaired/SmartSeq2SingleSampleUnpaired.wdl
+++ b/pipelines/smartseq2_single_sample_unpaired/SmartSeq2SingleSampleUnpaired.wdl
@@ -8,8 +8,6 @@ workflow SmartSeq2SingleCellUnpaired {
   meta {
     description: "Process SmartSeq2 scRNA-Seq data, include reads alignment, QC metrics collection, and gene expression quantitication"
   }
-  # version of this pipeline
-  String version = "smartseq2singleend_v1.0.0"
   # load annotation
   File genome_ref_fasta
   File rrna_intervals
@@ -118,8 +116,6 @@ workflow SmartSeq2SingleCellUnpaired {
 
 
   output {
-    # version of this pipeline
-    String pipeline_version = version
     # quality control outputs
     File aligned_bam = HISAT2SingleEnd.output_bam
     File bam_index = HISAT2SingleEnd.bam_index


### PR DESCRIPTION
### Purpose
Defining the analysis workflow version in the WDL itself requires keeping that hard-coded version variable up to date. This is prone to manual errors and complicates the release process for pipelines in Skylab.

### Changes
Remove this variable, so that the github tag is the source of truth for the pipeline version

Note: This should be merged after the adapter pipelines are updated to use the pipeline versions specified in Lira's config instead of the pipeline WDLs:
- https://github.com/HumanCellAtlas/adapter-pipelines/pull/6
- https://github.com/HumanCellAtlas/lira/pull/188

### Review Instructions
- No instructions.
