### PR TITLE
Update SmartSeq2 version to v2.5.0

### DIFF
--- a/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
+++ b/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl
@@ -9,7 +9,7 @@ workflow SmartSeq2SingleCell {
     description: "Process SmartSeq2 scRNA-Seq data, include reads alignment, QC metrics collection, and gene expression quantitication"
   }
   # version of this pipeline
-  String version = "smartseq2_v2.4.0"
+  String version = "smartseq2_v2.5.0"
   # load annotation
   File genome_ref_fasta
   File rrna_intervals


### PR DESCRIPTION
### Purpose
Since we removed the max retries parameter out of the SmartSeq2 pipeline (in order to allow us to set this value in the workflow options file), we need to tag a new version so that we can make use of this small change.

### Changes
- No changes.

### Review Instructions
- No instructions.
