### PR TITLE
Bump dependencies for vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
+.idea/
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/docker/analysis-tools/Dockerfile
+++ b/docker/analysis-tools/Dockerfile
@@ -70,10 +70,10 @@ RUN pip3 install \
     crimson==0.3.0 \
     HTSeq==0.9.0 \
     matplotlib==2.1.0 \
-    numpy==1.12.0 \
-    pandas==0.20.3 \
+    numpy==1.17.4 \
+    pandas==0.25.0 \
     pysam==0.12.0.1 \
-    requests==2.18.4 \
+    requests==2.20.0 \
     scipy==0.18.1 \
     sctools==0.1.4 \
     tables==3.4.2 \

--- a/docker/benchmarking-tools/Dockerfile
+++ b/docker/benchmarking-tools/Dockerfile
@@ -70,10 +70,10 @@ RUN pip3 install \
     crimson==0.3.0 \
     HTSeq==0.9.0 \
     matplotlib==2.1.0 \
-    numpy==1.12.0 \
-    pandas==0.20.3 \
+    numpy==1.17.4 \
+    pandas==0.25.0 \
     pysam==0.12.0.1 \
-    requests==2.18.4 \
+    requests==2.20.0 \
     scipy==0.18.1 \
     sctools==0.1.4 \
     tables==3.4.2 \

--- a/docker/cellranger/requirements.txt
+++ b/docker/cellranger/requirements.txt
@@ -2,11 +2,11 @@ docopt==0.6.2
 enum==0.4.6
 h5py==2.6.0
 illuminate==0.6.5
-jinja2==2.7.3
+jinja2==2.20.0
 matplotlib==1.5.1
-numpy==1.11.2
+numpy==1.17.4
 pyfasta==0.5.2
-pysam==0.9.1
+pysam==0.15.1
 PyVCF==0.6.8
 scikit-learn==0.17.1
 scipy==0.18.1

--- a/docker/python3-scientific/Dockerfile
+++ b/docker/python3-scientific/Dockerfile
@@ -11,10 +11,10 @@ RUN pip3 install \
     crimson==0.4.0 \
     HTSeq==0.9.0 \
     matplotlib==2.1.0 \
-    numpy==1.12.0 \
-    pandas==0.20.3 \
+    numpy==1.17.4 \
+    pandas==0.25.0 \
     pysam==0.12.0.1 \
-    requests==2.18.4 \
+    requests==2.20.0 \
     scipy==0.18.1 \
     sctools==0.1.6 \
     tables==3.4.2 \

--- a/docker/ss2-plate-aggregation/Dockerfile
+++ b/docker/ss2-plate-aggregation/Dockerfile
@@ -10,10 +10,10 @@ RUN pip3 install \
     crimson==0.4.0 \
     HTSeq==0.9.0 \
     matplotlib==2.1.0 \
-    numpy==1.12.0 \
-    pandas==0.20.3 \
+    numpy==1.17.4 \
+    pandas==0.25.0 \
     pysam==0.12.0.1 \
-    requests==2.18.4 \
+    requests==2.20.0 \
     scipy==0.18.1 \
     sctools==0.1.6 \
     tables==3.4.2 \

--- a/docker/subset-fastq-dataset/Dockerfile
+++ b/docker/subset-fastq-dataset/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Mint Team <mintteam@broadinstitute.org>" \
 
 RUN pip3 install \
     Click==7.0 \
-    numpy==1.16.2 \
+    numpy==1.17.4 \
     pysam==0.15.2 \
     biopython==1.73
 

--- a/docker/zarr-output/requirements.txt
+++ b/docker/zarr-output/requirements.txt
@@ -26,11 +26,11 @@ pytest==5.1.1
 python-dateutil==2.8.0
 pytz==2019.2
 PyYAML==5.1.2
-requests==2.18.4
+requests==2.20.0
 scipy==1.3.1
 sctools==0.1.6
 six==1.12.0
-urllib3==1.22
+urllib3==1.24.2
 wcwidth==0.1.7
 zarr==2.2.0
 zipp==0.5.2


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-158
Dependencies with vulnerabilities detected by Snyk and GitHub


### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Minor changes : new version of dependencies

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Review the impact on running the pipelines and the output
- Review the possibility to update the dependencies on sctools for those 3 pipelines:
1. Benchmarking-tools
2.analysis-tools
3.python3-scientific
Sctools recently updated and version should be bumped (new PR)

