### PR TITLE
GL-990 Check the file name for SS2 single end, rename if needed

### DIFF
--- a/library/tasks/HISAT2.wdl
+++ b/library/tasks/HISAT2.wdl
@@ -232,22 +232,30 @@ input {
 
   command {
     set -e
-    tar --no-same-owner -xvf "${hisat2_ref}"
+    tar --no-same-owner -xvf "~{hisat2_ref}"
+
+    # fix names if necessary.
+    if [ "~{fastq}" != *.fastq.gz ]; then
+        FQ=~{fastq}.fastq.gz
+        mv ~{fastq} ~{fastq}.fastq.gz
+    else
+        FQ=~{fastq}
+    fi
 
     # The parameters for this task are copied from the HISAT2PairedEnd task.
     hisat2 -t \
-      -x ${ref_name}/${ref_name} \
-      -U ${fastq} \
-      --rg-id=${sample_name} --rg SM:${sample_name} --rg LB:${sample_name} \
-      --rg PL:ILLUMINA --rg PU:${sample_name} \
-      --new-summary --summary-file "${output_basename}.log" \
-      --met-file ${output_basename}.hisat2.met.txt --met 5 \
+      -x ~{ref_name}/~{ref_name} \
+      -U $FQ \
+      --rg-id=~{sample_name} --rg SM:~{sample_name} --rg LB:~{sample_name} \
+      --rg PL:ILLUMINA --rg PU:~{sample_name} \
+      --new-summary --summary-file "~{output_basename}.log" \
+      --met-file ~{output_basename}.hisat2.met.txt --met 5 \
       --seed 12345 \
       -k 10 \
       --secondary \
-      -p ${cpu} -S >(samtools view -1 -h -o ${output_basename}_unsorted.bam)
-    samtools sort -@ ${cpu} -O bam -o "${output_basename}.bam" "${output_basename}_unsorted.bam"
-    samtools index "${output_basename}.bam"
+      -p ~{cpu} -S >(samtools view -1 -h -o ~{output_basename}_unsorted.bam)
+    samtools sort -@ ~{cpu} -O bam -o "~{output_basename}.bam" "~{output_basename}_unsorted.bam"
+    samtools index "~{output_basename}.bam"
   }
 
   runtime {

--- a/library/tasks/HISAT2.wdl
+++ b/library/tasks/HISAT2.wdl
@@ -234,7 +234,7 @@ input {
     set -e
     tar --no-same-owner -xvf "~{hisat2_ref}"
 
-    # fix names if necessary.
+    # fix file names if necessary.
     if [ "~{fastq}" != *.fastq.gz ]; then
         FQ=~{fastq}.fastq.gz
         mv ~{fastq} ~{fastq}.fastq.gz


### PR DESCRIPTION
### Purpose
- As part of the ticket to process SS2 data from HCA data browser in Terra, we need to accept fastq inputs that are not named with the `.fastq.gz` extension. Since the HISAT2 tool requires this file extension for internal validation, we must rename files if the extension is not present. The paired end version of this command was already doing this, but single-end was missing this step. 

### Changes
- This adds the check to the single-end hisat2 call to check input fastq file name ends in  `.fastq.gz` and rename the file if needed.

### Review Instructions
- No instructions.
