### PR TITLE
changed merged_bam output file name to sample_id.bam

### DIFF
--- a/library/tasks/MergeSortBam.wdl
+++ b/library/tasks/MergeSortBam.wdl
@@ -4,6 +4,7 @@ task MergeSortBamFiles {
   input {
     Array[File] bam_inputs
     String sort_order
+    String sample_id
 
     Int compression_level = 5
 
@@ -53,6 +54,6 @@ task MergeSortBamFiles {
     preemptible: preemptible
   }
   output {
-    File output_bam = "merged.bam"
+    File output_bam = "${sample_id}.bam"
   }
 }

--- a/pipelines/optimus/Optimus.changelog.md
+++ b/pipelines/optimus/Optimus.changelog.md
@@ -1,4 +1,4 @@
-#optimus_v3.0.0
+# optimus_v3.0.0
 
 * Removed zarr formatted matrix and metrics outputs and replaced with loom
 

--- a/pipelines/optimus/Optimus.wdl
+++ b/pipelines/optimus/Optimus.wdl
@@ -222,6 +222,7 @@ workflow Optimus {
   call Merge.MergeSortBamFiles as MergeSorted {
     input:
       bam_inputs = PreMergeSort.bam_output,
+      sample_id = sample_id,
       sort_order = "coordinate"
   }
 


### PR DESCRIPTION
### Purpose
Every bam made by Optimus is called merged.bam. From the DCP perspective, the infrastructure will require the outputs of pipelines to have a unique name for the entire HCA. From a user's perspective, they want certain names for their files. 

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
